### PR TITLE
Fixing: Hadoop prompt variability causes traffic to hang.

### DIFF
--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -142,7 +142,8 @@ class Impala(object):
         )
         self.shell = client.invoke_shell()
         self.connected = True
-        total = ""while len(total) == 0 or total[-10:] != ":21000] > ":
+        total = ""
+        while len(total) == 0 or total[-10:] != ":21000] > ":
             b = self.shell.recv(256)
             print("HERE:",b)
             total += b.decode()

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -145,10 +145,7 @@ class Impala(object):
         total = ""
         while len(total) == 0 or total[-10:] != ":21000] > ":
             b = self.shell.recv(256)
-            print("HERE:",b)
             total += b.decode()
-            print("THERE:",total)
-        print("DONE THIS BIT")
 
     def _impala(
         self, request: str, cached: bool = True

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -142,10 +142,12 @@ class Impala(object):
         )
         self.shell = client.invoke_shell()
         self.connected = True
-        total = ""
-        while len(total) == 0 or total[-19:] != "[hadoop-1:21000] > ":
+        total = ""while len(total) == 0 or total[-10:] != ":21000] > ":
             b = self.shell.recv(256)
+            print("HERE:",b)
             total += b.decode()
+            print("THERE:",total)
+        print("DONE THIS BIT")
 
     def _impala(
         self, request: str, cached: bool = True
@@ -164,7 +166,7 @@ class Impala(object):
             logging.info("Sending request: {}".format(request))
             self.shell.send(request + ";\n")
             total = ""
-            while len(total) == 0 or total[-19:] != "[hadoop-1:21000] > ":
+            while len(total) == 0 or total[-10:] != ":21000] > ":
                 b = self.shell.recv(256)
                 total += b.decode()
             with cachename.open("w") as fh:


### PR DESCRIPTION
By default it is assumed that the Hadoop prompt looks like this:
[hadoop-1:21000] > 
But in some cases it may be different, like this:
[hadoop-29:21000] > 
If this different prompt is seen then Traffic will hang while trying to get data from the impala shell.
This pull request addresses the prompt variability and prevents hanging.