### PR TITLE
Enables bounding box to be applied to live traffic

### DIFF
--- a/traffic/data/adsb/opensky.py
+++ b/traffic/data/adsb/opensky.py
@@ -181,7 +181,7 @@ class OpenSky(Impala):
             except AttributeError:
                 west, south, east, north = bounds
 
-            what += f"&lamin={south}&lamax={north}&lomin={west}&lomax={east}"
+            what += f"?lamin={south}&lamax={north}&lomin={west}&lomax={east}"
 
         c = requests.get(
             f"https://opensky-network.org/api/states/{what}", auth=self.auth


### PR DESCRIPTION
When requesting a bounding box using:
`sv			=	opensky.api_states(bounds=(lon_min,lat_min,lon_max,lat_max))`
Python will throw an error, as the bounding box is passed incorrectly. According to opensky documentation the lamin,lomin, etc variables should be passed with a '?' at the start, not with an &.

This pull request updates this line:
https://github.com/xoolive/traffic/blob/master/traffic/data/adsb/opensky.py#L184
Changing the & to a ? and enabling a successful request.