### PR TITLE
Fix normalization in 3d Douglas-Peucker calculation

### DIFF
--- a/traffic/algorithms/douglas_peucker.py
+++ b/traffic/algorithms/douglas_peucker.py
@@ -30,7 +30,7 @@ def _douglas_peucker_rec_3d(x: np.ndarray, y: np.ndarray, z: np.ndarray,
     start = np.array([x[0], y[0], z[0]])
     end = np.array([x[-1], y[-1], z[-1]])
     point = np.dstack([x[1:], y[1:], z[1:]])[0] - start
-    d = np.cross(point/np.linalg.norm(point), start-end)
+    d = np.cross(point, (start-end)/np.linalg.norm(start-end))
     d = np.sqrt(np.sum(d*d, axis=1))
 
     if np.max(d) < tolerance:


### PR DESCRIPTION
Example code:
```from traffic.algorithms import douglas_peucker
import pandas as pd
x = [0, 100, 200]
y = [0, 1, 0]
z = [0, 0, 0]
df2d = pd.DataFrame({'x': x, 'y': y})
df3d = pd.DataFrame({'x': x, 'y': y, 'z':z})
print('Douglas-Peucker boolean map in 2d:', douglas_peucker(df=df2d, tolerance=1))
print('Douglas-Peucker boolean map in 3d:', douglas_peucker(df=df3d, z='z', tolerance=1, z_factor=1))
```

Result:
```Douglas-Peucker boolean map in 2d: [ True  True  True]
Douglas-Peucker boolean map in 3d: [ True False  True]
```

Problem: despite adding only an additional dimension not changing the geometry, the middle point is dropped, when calculating in 3d.

Reason: calculation of the deviation in 3d is wrong due to wrong normalisation.

After the fix the result is correctly:
```Douglas-Peucker boolean map in 2d: [ True  True  True]
Douglas-Peucker boolean map in 3d: [ True  True  True]
```