### PR TITLE
Allow user-selectable cache directory

### DIFF
--- a/traffic/__init__.py
+++ b/traffic/__init__.py
@@ -14,7 +14,6 @@ warnings.simplefilter("ignore", TqdmExperimentalWarning)
 # -- Configuration management --
 
 config_dir = Path(user_config_dir("traffic"))
-cache_dir = Path(user_cache_dir("traffic"))
 config_file = config_dir / "traffic.conf"
 
 if not config_dir.exists():
@@ -30,11 +29,19 @@ enabled_plugins = CesiumJS, Leaflet
 """
         )
 
-if not cache_dir.exists():
-    cache_dir.mkdir(parents=True)
-
 config = configparser.ConfigParser()
 config.read(config_file.as_posix())
+
+# Check the config file for a cache directory. If not present
+# then use the system default cache path
+cache_dir = config.get("global", "cache_dir", fallback="")
+if (cache_dir == ""):
+    cache_dir = Path(user_cache_dir("traffic"))
+else:
+    cache_dir = Path(cache_dir)
+
+if not cache_dir.exists():
+    cache_dir.mkdir(parents=True)
 
 # -- Plugin management --
 


### PR DESCRIPTION
Hello!
I just ran into a problem with filling my home directory when downloading lots of data, as by default the cache directory is in `~/.cache/`

This pull request allows a different `cache_dir` to be selected by the user if they add the `cache_dir=/my/cache/dir/` option to their configuration file. If this option is not present, or if this option is `""` then the original behaviour is continued.

I'm not sure that my adding this behaviour in the `__init__.py` file is ideal, so am happy to move this to another file if that's more appropriate!