### PR TITLE
Allow wildcard search on Impala for callsign

### DIFF
--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -355,8 +355,11 @@ class Impala(object):
             other_params += "and icao24 in ({}) ".format(icao24)
 
         if isinstance(callsign, str):
-            other_params += "and callsign='{:<8s}' ".format(callsign)
-            return_flight = True
+            if callsign.find('%') > 0 or callsign.find('_') > 0:
+                other_params += "and callsign ilike '{}' ".format(callsign)
+            else:
+                other_params += "and callsign='{:<8s}' ".format(callsign)
+                return_flight = True
 
         elif isinstance(callsign, Iterable):
             callsign = ",".join("'{:<8s}'".format(c) for c in callsign)


### PR DESCRIPTION
Allow SQL wildcards '_' and '%' to filter the callsigns on Impala