### PR TITLE
Explicit proxy settings in the configuration files

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,40 @@ Troubleshooting
 ---------------
 
 The following reported problems are not about the traffic library per
-se but related to limitations set by dependencies.
+se. Some are related to limitations set by dependencies.
+
+I can't access resources from the Internet as I am behind a proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All network accesses are made with the `requests
+<https://requests.readthedocs.io/>`_ library (or the `paramiko
+<http://www.paramiko.org/>`_ library for the Impala shell). Usually, if your
+environment variables are properly set, you should not encounter any particular
+proxy issue. However, there are always situations where it may help to manually
+force the proxy settings in the configuration file.
+
+Edit your configuration file (you may find where it is located in
+traffic.config_file) and add the following section. Uncomment and edit options
+according to your network configuration.
+
+.. parsed-literal::
+    ## This sections contains all the specific options necessary to fit your
+    ## network configuration (including proxy and ProxyCommand settings)
+    [network]
+
+    ## input here the arguments you need to pass as is to requests
+    # http.proxy = http://proxy.company:8080
+    # https.proxy = http://proxy.company:8080
+    # http.proxy = socks5h://localhost:1234
+    # https.proxy = socks5h://localhost:1234
+
+    ## input here the ProxyCommand you need to login to the Impala Shell
+    ## WARNING:
+    ##    Do not use %h and %p wildcards.
+    ##    Write data.opensky-network.org and 2230 explicitly instead
+    # ssh.proxycommand = ssh -W data.opensky-network.org:2230 proxy_ip:proxy_port
+    # ssh.proxycommand = connect.exe -H proxy_ip:proxy_port data.opensky-network.org 2230
+
 
 Python crashes when I try to reproduce plots in the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         # deactivated for now for dependency issues
         # "keplergl",  # Kepler.gl for notebooks
         "tqdm>=4.28",  # progressbars
-        "cartotools>=1.1",
+        "cartotools>=1.2",
         "pyModeS>=2.4",
     ],
     classifiers=[

--- a/traffic/core/flightplan.py
+++ b/traffic/core/flightplan.py
@@ -161,6 +161,10 @@ class DirectPoint(Point):
 
 
 class SID(Airway):
+    @classmethod
+    def valid(cls, elt: str) -> bool:
+        return bool(re.match(cls.pattern, elt))
+
     def get(self, airport: Optional[str] = None) -> Optional[Route]:
         from traffic.data import airways, nm_airways
 
@@ -181,6 +185,10 @@ class SID(Airway):
 
 
 class STAR(Airway):
+    @classmethod
+    def valid(cls, elt: str) -> bool:
+        return bool(re.match(cls.pattern, elt))
+
     def get(self, airport: Optional[str] = None) -> Optional[Route]:
         from traffic.data import airways, nm_airways
 

--- a/traffic/data/__init__.py
+++ b/traffic/data/__init__.py
@@ -3,6 +3,7 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
+from cartotools import session as carto_session
 from requests import Session
 
 from .. import cache_dir, config, config_file
@@ -78,6 +79,9 @@ session = Session()
 if len(proxy_values) > 0:
     session.proxies.update(proxy_values)
     session.trust_env = False
+
+    carto_session.proxies.update(proxy_values)
+    carto_session.trust_env = False
 
 pkcs12_filename = config.get("nmb2b", "pkcs12_filename", fallback="")
 pkcs12_password = config.get("nmb2b", "pkcs12_password", fallback="")

--- a/traffic/data/__init__.py
+++ b/traffic/data/__init__.py
@@ -62,8 +62,9 @@ opensky_username = config.get("global", "opensky_username", fallback="")
 opensky_password = config.get("global", "opensky_password", fallback="")
 
 # We keep "" for forcing to no proxy
-http_proxy = config.get("proxy", "http", fallback="<>")
-https_proxy = config.get("proxy", "https", fallback="<>")
+http_proxy = config.get("network", "http.proxy", fallback="<>")
+https_proxy = config.get("network", "https.proxy", fallback="<>")
+paramiko_proxy = config.get("network", "ssh.proxycommand", fallback="")
 
 proxy_values = dict(
     (key, value)
@@ -91,7 +92,12 @@ if sys.version_info < (3, 7, 0):
     nm_navaids = NMNavaids.from_file(nm_path_str)
     nm_airways = NMRoutes()
 
-    opensky = OpenSky(opensky_username, opensky_password, cache_dir / "opensky")
+    opensky = OpenSky(
+        opensky_username,
+        opensky_password,
+        cache_dir / "opensky",
+        paramiko_proxy,
+    )
     if len(proxy_values) > 0:
         opensky.session.proxies.update(proxy_values)
         opensky.session.trust_env = False
@@ -130,7 +136,10 @@ def __getattr__(name: str):
         return NMRoutes()
     if name == "opensky":
         opensky = OpenSky(
-            opensky_username, opensky_password, cache_dir / "opensky"
+            opensky_username,
+            opensky_password,
+            cache_dir / "opensky",
+            paramiko_proxy,
         )
         if len(proxy_values) > 0:
             opensky.session.proxies.update(proxy_values)

--- a/traffic/data/adsb/opensky.py
+++ b/traffic/data/adsb/opensky.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from typing import Optional, Set, Tuple, Union
 
 import pandas as pd
-import requests
 from cartopy.crs import PlateCarree
 from cartopy.mpl.geoaxes import GeoAxesSubplot
 from matplotlib.artist import Artist
 from matplotlib.patches import Polygon as MplPolygon
+from requests import Session
 from shapely.geometry import Polygon
 from shapely.geometry.base import BaseGeometry
 
@@ -132,10 +132,15 @@ class OpenSky(Impala):
     ]
 
     def __init__(
-        self, username: str, password: str, cache_dir: Path, proxy_command: str
+        self,
+        username: str,
+        password: str,
+        cache_dir: Path,
+        session: Session,
+        proxy_command: str,
     ) -> None:
         super().__init__(username, password, cache_dir, proxy_command)
-        self.session = requests.Session()
+        self.session = session
 
     def api_states(
         self,

--- a/traffic/data/adsb/opensky.py
+++ b/traffic/data/adsb/opensky.py
@@ -131,8 +131,10 @@ class OpenSky(Impala):
         "position_source",
     ]
 
-    def __init__(self, username: str, password: str, cache_dir: Path) -> None:
-        super().__init__(username, password, cache_dir)
+    def __init__(
+        self, username: str, password: str, cache_dir: Path, proxy_command: str
+    ) -> None:
+        super().__init__(username, password, cache_dir, proxy_command)
         self.session = requests.Session()
 
     def api_states(

--- a/traffic/data/basic/aircraft.py
+++ b/traffic/data/basic/aircraft.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import pandas as pd
-import requests
+
 from tqdm.autonotebook import tqdm
 
 
@@ -50,7 +50,9 @@ class Aircraft(object):
 
         url: https://junzisun.com/adb/download
         """
-        f = requests.get("https://junzisun.com/adb/download")
+        from .. import session
+
+        f = session.get("https://junzisun.com/adb/download")
         with zipfile.ZipFile(io.BytesIO(f.content)) as zfile:
             with zfile.open("aircraft_db.csv", "r") as dbfile:
                 self._junzis = (
@@ -90,11 +92,13 @@ class Aircraft(object):
 
         url: https://opensky-network.org/aircraft-database
         """
+        from .. import session
+
         logging.warning("Downloading OpenSky aircraft database")
         file_url = (
             "https://opensky-network.org/datasets/metadata/aircraftDatabase.csv"
         )
-        f = requests.get(file_url, stream=True)
+        f = session.get(file_url, stream=True)
         total = int(f.headers["Content-Length"])
         buffer = io.BytesIO()
         for chunk in tqdm(

--- a/traffic/data/basic/airports.py
+++ b/traffic/data/basic/airports.py
@@ -4,9 +4,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Optional
 
-import altair as alt
 import pandas as pd
-import requests
+
+import altair as alt
 
 from ...core.mixins import GeoDBMixin, PointMixin, ShapelyMixin
 from ...core.structure import Airport
@@ -56,7 +56,9 @@ class Airports(GeoDBMixin):
         self._data: Optional[pd.DataFrame] = data
 
     def download_fr24(self) -> None:  # coverage: ignore
-        c = requests.get(
+        from .. import session
+
+        c = session.get(
             "https://www.flightradar24.com/_json/airports.php",
             headers={"user-agent": "Mozilla/5.0"},
         )

--- a/traffic/data/basic/airways.py
+++ b/traffic/data/basic/airways.py
@@ -1,4 +1,5 @@
 import logging
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -85,9 +86,12 @@ class Airways(GeoDBMixin):
         return instance
 
     def download_data(self) -> None:  # coverage: ignore
-        self._data = pd.read_csv(
-            base_url + "/earth_awy.dat", sep=" ", header=None
-        )
+        from .. import session
+
+        c = session.get(base_url + "/earth_awy.dat")
+        c.raise_for_status()
+        b = BytesIO(c.content)
+        self._data = pd.read_csv(b, sep=" ", header=None)
         self._data.columns = ["route", "id", "navaid", "latitude", "longitude"]
         self._data.to_pickle(self.cache_dir / "traffic_airways.pkl")
 

--- a/traffic/data/basic/navaid.py
+++ b/traffic/data/basic/navaid.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Dict, Iterator, NamedTuple, Optional, Tuple, Union
 
 import pandas as pd
-import requests
 
 from ...core.mixins import GeoDBMixin, PointMixin, ShapelyMixin
 from ...core.structure import Navaid, NavaidTuple
@@ -68,8 +67,10 @@ class Navaids(GeoDBMixin):
         repository.
         """
 
+        from .. import session
+
         navaids = []
-        c = requests.get(f"{base_url}/earth_fix.dat")
+        c = session.get(f"{base_url}/earth_fix.dat")
 
         for line in c.iter_lines():
 
@@ -100,7 +101,7 @@ class Navaids(GeoDBMixin):
                 )
             )
 
-        c = requests.get(f"{base_url}/earth_nav.dat")
+        c = session.get(f"{base_url}/earth_nav.dat")
 
         for line in c.iter_lines():
 

--- a/traffic/data/basic/runways.py
+++ b/traffic/data/basic/runways.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from zipfile import ZipFile
 
 import pandas as pd
-import requests
 from shapely.geometry import base, shape
 from shapely.ops import linemerge
 
@@ -127,9 +126,10 @@ class Runways(object):
         return RunwayAirport(self.runways[airport.icao])
 
     def download_bluesky(self) -> None:  # coverage: ignore
-        self._runways = dict()
+        from .. import session
 
-        c = requests.get(base_url + "/apt.zip")
+        self._runways = dict()
+        c = session.get(base_url + "/apt.zip")
 
         with ZipFile(BytesIO(c.content)).open("apt.dat", "r") as fh:
             for line in fh.readlines():

--- a/traffic/data/datasets/__init__.py
+++ b/traffic/data/datasets/__init__.py
@@ -2,8 +2,6 @@ import io
 from hashlib import md5
 from typing import Any, Dict
 
-import requests
-
 from tqdm.autonotebook import tqdm
 
 from ... import cache_dir
@@ -34,8 +32,9 @@ __all__ = list(datasets.keys())
 
 
 def download_data(dataset: Dict[str, str]) -> io.BytesIO:
+    from .. import session
 
-    f = requests.get(dataset["url"], stream=True)
+    f = session.get(dataset["url"], stream=True)
     total = int(f.headers["Content-Length"])
     buffer = io.BytesIO()
     for chunk in tqdm(

--- a/traffic/data/eurocontrol/b2b/__init__.py
+++ b/traffic/data/eurocontrol/b2b/__init__.py
@@ -6,6 +6,7 @@ from xml.dom import minidom
 from xml.etree import ElementTree
 
 from requests import Session
+
 from requests_pkcs12 import Pkcs12Adapter
 from tqdm.autonotebook import tqdm
 
@@ -64,12 +65,13 @@ class NMB2B(FlightManagement, Measures):
         self,
         mode: Dict[str, str],
         version: str,
+        session: Session,
         pkcs12_filename: Union[str, Path],
         pkcs12_password: str,
     ) -> None:
         self.mode = mode
         self.version = version
-        self.session = Session()
+        self.session = session
         self.session.mount(
             mode["base_url"],
             Pkcs12Adapter(

--- a/traffic/data/faa/airspace_boundaries.py
+++ b/traffic/data/faa/airspace_boundaries.py
@@ -2,7 +2,6 @@ import json
 import logging
 from typing import Dict
 
-import requests
 from shapely.geometry import shape
 
 from ...core.airspace import Airspace, ExtrudedPolygon
@@ -21,10 +20,12 @@ def get_airspaces() -> Dict[str, Airspace]:
         with filename.open("r") as fh:
             json_contents = json.load(fh)
     else:
+        from .. import session
+
         logging.warning(
             f"Downloading data from {website}. Please check terms of use."
         )
-        c = requests.get(json_url)
+        c = session.get(json_url)
         c.raise_for_status()
         json_contents = c.json()
         with filename.open("w") as fh:


### PR DESCRIPTION
All network accesses are made with the requests library (or the paramiko library for the Impala shell). Usually, if your environment variables are properly set, you should not encounter any particular proxy issue. However, there are always situations where it may help to manually force the proxy settings in the configuration file.

Edit your configuration file (you may find where it is located in `traffic.config_file`) and add the following section. Uncomment and edit options according to your network configuration.

```
## This sections contains all the specific options necessary to fit your
## network configuration (including proxy and ProxyCommand settings)
[network]

## input here the arguments you need to pass as is to requests
# http.proxy = http://proxy.company:8080
# https.proxy = http://proxy.company:8080
# http.proxy = socks5h://localhost:1234
# https.proxy = socks5h://localhost:1234

## input here the ProxyCommand you need to login to the Impala Shell
## WARNING:
##    Do not use %h and %p wildcards
##    Write data.opensky-network.org and 2230 explicitely instead
# ssh.proxycommand = ssh -W data.opensky-network.org:2230 proxy_ip:proxy_port
# ssh.proxycommand = connect.exe -H proxy_ip:proxy_port data.opensky-network.org 2230
```
