### PR TITLE
Allow variable linewidth in altair plots

### DIFF
--- a/traffic/core/mixins.py
+++ b/traffic/core/mixins.py
@@ -310,12 +310,12 @@ class ShapelyMixin(object):
         """
         return mapping(self.shape)
 
-    def geoencode(self) -> alt.Chart:  # coverage: ignore
+    def geoencode(self, linewidth=1) -> alt.Chart:  # coverage: ignore
         """Returns an `altair <http://altair-viz.github.io/>`_ encoding of the
         shape to be composed in an interactive visualization.
         """
         return alt.Chart(alt.Data(values=self.geojson())).mark_geoshape(
-            stroke="#aaaaaa", strokeWidth=1
+            stroke="#aaaaaa", strokeWidth=linewidth
         )
 
     def project_shape(
@@ -463,7 +463,7 @@ class GeographyMixin(DataFrameMixin):
 
         return data
 
-    def geoencode(self) -> alt.Chart:  # coverage: ignore
+    def geoencode(self, linewidth=1) -> alt.Chart:  # coverage: ignore
         """Returns an `altair <http://altair-viz.github.io/>`_ encoding of the
         shape to be composed in an interactive visualization.
         """
@@ -474,7 +474,7 @@ class GeographyMixin(DataFrameMixin):
                 )[["latitude", "longitude"]]
             )
             .encode(latitude="latitude", longitude="longitude")
-            .mark_line()
+            .mark_line(strokeWidth=linewidth)
         )
 
 


### PR DESCRIPTION
Currently, the plots produced by `geoencode()` have a fixed linewidth (either `1` or whatever the Altair default is). for cases when a lot of flights are being plotted on one graph, this generates a messy output as the lines are often too wide.

This PR allows the user to set their own linewidth, if desired, by using:
`flight.geoencode(linewidth=0.5)`.
If no linewidth is specified then the default option is used instead.