### PR TITLE
Fix rawdata as string.

### DIFF
--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -191,7 +191,7 @@ class Impala(object):
         )
 
         if "rawmsg" in df.columns and df.rawmsg.dtype != str:
-            df.rawmsg = str(df.rawmsg).strip()
+	        df.rawmsg = df.rawmsg.astype(str).str.strip()
 
         if "squawk" in df.columns:
             df.squawk = (

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -190,6 +190,9 @@ class Impala(object):
             .str.pad(6, fillchar="0")
         )
 
+        if "rawmsg" in df.columns and df.rawmsg.dtype != str:
+            df.rawmsg = str(df.rawmsg).strip()
+
         if "squawk" in df.columns:
             df.squawk = (
                 df.squawk.astype(str)


### PR DESCRIPTION
Occasionally,
`ehs_flights = flights.query_ehs().eval()` gives an error, because the `rawmsg` value in a dataframe can be interpreted as an integer (i.e: It only contains numerals, no letters).
This PR forces the rawmsg to be a string, fixing the problem.