### PR TITLE
Add time to api_tracks

### DIFF
--- a/traffic/data/adsb/opensky.py
+++ b/traffic/data/adsb/opensky.py
@@ -211,7 +211,7 @@ class OpenSky(Impala):
 
         return StateVectors(r, self)
 
-    def api_tracks(self, icao24: str) -> Flight:
+    def api_tracks(self, icao24: str, time: Optional[timelike] = None) -> Flight:
         """Returns a Flight corresponding to a given aircraft.
 
         Official documentation
@@ -245,8 +245,9 @@ class OpenSky(Impala):
         detailed track information.
 
         """
+        time = int(to_datetime(time).timestamp()) if time is not None else 0
         c = self.session.get(
-            f"https://opensky-network.org/api/tracks/?icao24={icao24}"
+            f"https://opensky-network.org/api/tracks/?icao24={icao24}&time={time}"
         )
         c.raise_for_status()
         json = c.json()


### PR DESCRIPTION
Hi,

As it is available in the OpenSky API, users should be able to ask for certain tracks in past time. So I added this parameter to the api_tracks function as done in other similar definitions.

