### PR TITLE
Improvements on Impala query generation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: "42 7 * * 0" # Every Sunday morning when I am fast asleep :)
     # This is useful for keeping the cache fit and ready

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,7 +70,7 @@ jobs:
           OPENSKY_USERNAME: ${{ secrets.OPENSKY_USERNAME }}
           OPENSKY_PASSWORD: ${{ secrets.OPENSKY_PASSWORD }}
         run: |
-          poetry run pytest --log-level=DEBUG
+          poetry run pytest
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,5 +74,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        if: $ {{ github.event_name != "pull_request_target" }}
         with:
           env_vars: PYTHON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,5 +142,5 @@ module = "traffic.core.*"
 # disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
-# addopts = "--cov --cov-report term-missing"
+addopts = "--cov --cov-report term-missing"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,5 +142,5 @@ module = "traffic.core.*"
 # disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report term-missing"
+addopts = "--cov --cov-report term-missing --log-debug=DEBUG"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,5 +142,5 @@ module = "traffic.core.*"
 # disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report term-missing"
+# addopts = "--cov --cov-report term-missing"
 testpaths = ["tests"]

--- a/tests/test_impala.py
+++ b/tests/test_impala.py
@@ -1,5 +1,3 @@
-import os
-import shutil
 from datetime import timedelta
 from typing import Optional, cast
 

--- a/tests/test_impala.py
+++ b/tests/test_impala.py
@@ -174,7 +174,6 @@ def test_complex_queries():
     tD = opensky.history(
             start="2021-08-24 00:00",
             stop="2021-08-24 01:00",
-            departure_airport="ESSA",
             count=True,
             bounds=[17.8936, 59.6118, 17.9894, 59.6716],
             limit=3,

--- a/tests/test_impala.py
+++ b/tests/test_impala.py
@@ -69,32 +69,40 @@ def test_complex_queries():
             stop="2021-08-24 01:00",
             airport="ESSA",
             arrival_airport="EGLL",
-            limit=3,
         )
-
+    # test that `limit` generate correct query
     t2 = opensky.history(
         start="2021-08-24 00:00",
         stop="2021-08-24 01:00",
         airport="ESSA",
         limit=3,
     )
-    assert t2 is not None
+    assert len(t2.data) == 3
+
+    t2_1 = opensky.history(
+        start="2021-08-24 09:00",
+        stop= "2021-08-24 09:10",
+        airport="ESSA",
+    )
+    assert len(t2_1) == 23
 
     t3 = opensky.history(
-        start="2021-08-24 00:00",
-        stop="2021-08-24 01:00",
+        start="2021-08-24 09:00",
+        stop= "2021-08-24 09:10",
         arrival_airport="ESSA",
-        limit=3,
     )
-    assert t3 is not None
+    assert len(t3) == 13
 
     t4 = opensky.history(
-        start="2021-08-24 00:00",
+        start="2021-08-24 11:32",
+        stop= "2021-08-24 11:42",
         departure_airport="ESSA",
         arrival_airport="EGLL",
-        limit=3,
     )
-    assert t4 is not None
+    assert len(t4) == 1
+    flight = t4["BAW777C"]
+    assert flight is not None
+    assert flight.icao24 == "400936"    
 
     with pytest.raises(RuntimeError, match=error_msg):
         _ = opensky.history(
@@ -107,78 +115,92 @@ def test_complex_queries():
 
     t6 = opensky.history(
         start="2021-08-24 00:00",
-        stop="2021-08-24 01:00",
+        stop= "2021-08-24 00:10",
         arrival_airport="ESSA",
         serials=-1408232560,
-        limit=3,
     )
-    assert t6 is not None
+    assert len(t6) == 1
+    flight = t6[0]
+    assert flight is not None
+    assert flight.callsign == "SAS6906"    
+    assert flight.icao24 == "4ca863"    
 
     t7 = opensky.history(
         start="2021-08-24 00:00",
-        stop="2021-08-24 01:00",
+        stop= "2021-08-24 00:10",
         serials=(-1408232560, -1408232534),
-        limit=3,
     )
-    assert t7 is not None
+    assert len(t7) == 12
 
     t8 = opensky.history(
-        start="2021-08-24 00:00",
-        stop="2021-08-24 01:00",
+        start="2021-08-24 09:00",
+        stop= "2021-08-24 09:10",
         departure_airport="ESSA",
         serials=(-1408232560, -1408232534),
-        limit=3,
     )
-    assert t8 is not None
+    assert len(t8) == 1
+    flight = t8[0]
+    assert flight is not None
+    assert flight.callsign == "LOT454"    
+    assert flight.icao24 == "489789"    
 
     t9 = opensky.history(
-            start="2021-08-24 00:00",
-            stop="2021-08-24 01:00",
-            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
-            serials=(-1408232560, -1408232534),
-            limit=3,
-        )
-    assert t9 is not None
+        start="2021-08-24 09:00",
+        stop= "2021-08-24 09:10",
+        bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+        serials=(-1408232560, -1408232534),
+    )
+    assert len(t9) == 9
+    flight = t9["SAS1136"]
+    assert flight is not None
+    assert flight.icao24 == "51110b"    
 
     tA = opensky.history(
-            start="2021-08-24 00:00",
-            stop="2021-08-24 01:00",
-            departure_airport="ESSA",
-            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
-            serials=(-1408232560, -1408232534),
-            limit=3,
-        )
-    assert tA is not None
+        start="2021-08-24 09:30",
+        stop= "2021-08-24 09:40",
+        departure_airport="ESSA",
+        bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+        serials=(-1408232560, -1408232534),
+    )
+    assert len(tA) == 1
+    flight = tA[0]
+    assert flight is not None
+    assert flight.callsign == "THY5HT"    
+    assert flight.icao24 == "4bb1c5"    
 
     tB = opensky.history(
-            start="2021-08-24 00:00",
-            stop="2021-08-24 01:00",
-            departure_airport="ESSA",
-            count=True,
-            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
-            serials=(-1408232560, -1408232534),
-            limit=3,
-        )
-    assert tB is not None
+        start="2021-08-24 09:45",
+        stop= "2021-08-24 09:50",
+        departure_airport="ESSA",
+        count=True,
+        bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+        serials=(-1408232560, -1408232534),
+    )
+    assert len(tB) == 1
+    flight = tB[0]
+    assert flight is not None
+    assert flight.callsign == "SAS69E"    
+    assert flight.icao24 == "4ac9e5"    
 
     tC = opensky.history(
-            start="2021-08-24 00:00",
-            stop="2021-08-24 01:00",
-            departure_airport="ESSA",
-            count=True,
-            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
-            limit=3,
-        )
-    assert tC is not None
+        start="2021-08-24 09:45",
+        stop= "2021-08-24 09:50",
+        departure_airport="ESSA",
+        count=True,
+        bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+    )
+    assert len(tC) == 1
+    flight = tC[0]
+    assert flight is not None
+    assert flight.callsign == "SAS69E"    
+    assert flight.icao24 == "4ac9e5"    
 
     tD = opensky.history(
-            start="2021-08-24 00:00",
-            stop="2021-08-24 01:00",
-            count=True,
-            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
-            limit=3,
-        )
-    assert tD is not None
+        start="2021-08-24 09:45",
+        stop= "2021-08-24 09:50",
+        bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+    )
+    assert len(tD) == 9
 
 def test_rawdata():
 

--- a/tests/test_impala.py
+++ b/tests/test_impala.py
@@ -131,6 +131,55 @@ def test_complex_queries():
     )
     assert t8 is not None
 
+    t9 = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+            serials=(-1408232560, -1408232534),
+            limit=3,
+        )
+    assert t9 is not None
+
+    tA = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            departure_airport="ESSA",
+            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+            serials=(-1408232560, -1408232534),
+            limit=3,
+        )
+    assert tA is not None
+
+    tB = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            departure_airport="ESSA",
+            count=True,
+            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+            serials=(-1408232560, -1408232534),
+            limit=3,
+        )
+    assert tB is not None
+
+    tC = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            departure_airport="ESSA",
+            count=True,
+            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+            limit=3,
+        )
+    assert tC is not None
+
+    tD = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            departure_airport="ESSA",
+            count=True,
+            bounds=[17.8936, 59.6118, 17.9894, 59.6716],
+            limit=3,
+        )
+    assert tD is not None
 
 def test_rawdata():
 

--- a/tests/test_impala.py
+++ b/tests/test_impala.py
@@ -1,5 +1,9 @@
+import os
+import shutil
 from datetime import timedelta
 from typing import Optional, cast
+
+import pytest
 
 from traffic.core import Traffic
 from traffic.data import opensky
@@ -57,6 +61,77 @@ def test_history():
 
     t_decoded = t_tma.filter().query_ehs(df).eval(desc="", max_workers=4)
     assert len(t_decoded) == len(t_tma)
+
+
+def test_complex_queries():
+    error_msg = "airport may not be set if arrival_airport is set"
+    with pytest.raises(RuntimeError, match=error_msg):
+        _ = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            airport="ESSA",
+            arrival_airport="EGLL",
+            limit=3,
+        )
+
+    t2 = opensky.history(
+        start="2021-08-24 00:00",
+        stop="2021-08-24 01:00",
+        airport="ESSA",
+        limit=3,
+    )
+    assert t2 is not None
+
+    t3 = opensky.history(
+        start="2021-08-24 00:00",
+        stop="2021-08-24 01:00",
+        arrival_airport="ESSA",
+        limit=3,
+    )
+    assert t3 is not None
+
+    t4 = opensky.history(
+        start="2021-08-24 00:00",
+        departure_airport="ESSA",
+        arrival_airport="EGLL",
+        limit=3,
+    )
+    assert t4 is not None
+
+    with pytest.raises(RuntimeError, match=error_msg):
+        _ = opensky.history(
+            start="2021-08-24 00:00",
+            stop="2021-08-24 01:00",
+            airport="ESSA",
+            arrival_airport="EGLL",
+            limit=3,
+        )
+
+    t6 = opensky.history(
+        start="2021-08-24 00:00",
+        stop="2021-08-24 01:00",
+        arrival_airport="ESSA",
+        serials=-1408232560,
+        limit=3,
+    )
+    assert t6 is not None
+
+    t7 = opensky.history(
+        start="2021-08-24 00:00",
+        stop="2021-08-24 01:00",
+        serials=(-1408232560, -1408232534),
+        limit=3,
+    )
+    assert t7 is not None
+
+    t8 = opensky.history(
+        start="2021-08-24 00:00",
+        stop="2021-08-24 01:00",
+        departure_airport="ESSA",
+        serials=(-1408232560, -1408232534),
+        limit=3,
+    )
+    assert t8 is not None
 
 
 def test_rawdata():

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -795,8 +795,8 @@ class Impala(object):
             except AttributeError:
                 west, south, east, north = bounds
 
-            other_params += "and lon>={} and lon<={} ".format(west, east)
-            other_params += "and lat>={} and lat<={} ".format(south, north)
+            other_params += "and sv.lon>={} and sv.lon<={} ".format(west, east)
+            other_params += "and sv.lat>={} and sv.lat<={} ".format(south, north)
 
         day_min = round_time(start, how="before", by=timedelta(days=1))
         day_max = round_time(stop, how="after", by=timedelta(days=1))

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -864,7 +864,7 @@ class Impala(object):
                 day_max=day_max.timestamp(),
             )
 
-        cumul = []
+        cumul: List[pd.DataFrame] = []
         sequence = list(split_times(start, stop, date_delta))
         columns = ", ".join(f"sv.{field}" for field in self._impala_columns)
         parse_columns = ", ".join(self._impala_columns)
@@ -912,8 +912,7 @@ class Impala(object):
                 other_params=other_params,
                 where_clause=where_clause,
             )
-            logging.info(f"Sending Impala request: {request}")
-            return request
+
             df = self._impala(request, columns=parse_columns, cached=cached)
 
             if df is None:

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -301,6 +301,12 @@ class Impala(object):
     def _format_history(
         df: pd.DataFrame, nautical_units: bool = True
     ) -> pd.DataFrame:
+        """
+        This function can be used in tandem with `_format_dataframe()` to
+        convert (historical data specific) column types and optionally convert
+        the units back to nautical miles, feet and feet/min.
+
+        """
 
         if "lastcontact" in df.columns:
             df = df.drop(["lastcontact"], axis=1)

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -759,7 +759,7 @@ class Impala(object):
 
         elif isinstance(icao24, Iterable):
             icao24 = ",".join("'{}'".format(c.lower()) for c in icao24)
-            other_params += "and sv.icao24 in ({}) ".format(icao24.lower())
+            other_params += "and sv.icao24 in ({}) ".format(icao24)
 
         if isinstance(callsign, str):
             if (
@@ -825,6 +825,10 @@ class Impala(object):
             )
 
         elif arrival_airport is not None:
+            if airport is not None:
+                raise RuntimeError(
+                    "airport may not be set if " "arrival_airport is set"
+                )
             other_tables += (
                 "join (select icao24 as e_icao24, firstseen, "
                 "estdepartureairport, lastseen, estarrivalairport, "
@@ -838,6 +842,10 @@ class Impala(object):
             )
 
         elif departure_airport is not None:
+            if airport is not None:
+                raise RuntimeError(
+                    "airport may not be set if " "departure_airport is set"
+                )
             other_tables += (
                 "join (select icao24 as e_icao24, firstseen, "
                 "estdepartureairport, lastseen, estarrivalairport, "
@@ -886,7 +894,7 @@ class Impala(object):
             )
 
         if count is True:
-            other_params += "group by " + columns
+            other_params += "group by " + columns + " "
             columns = "count(*) as count, " + columns
             parse_columns = "count, " + parse_columns
             if serials is None:


### PR DESCRIPTION
This is still WIP.
It seems to work for the normal cases.

Also the query generated when serials and airport are specified seems ok: but veeeerrryyy slow when executed on my machine, so much that I gave up.

I need to understand how to intercept the logged request sent to Impala...I see the `logging.info` to spit it but I am too unexperienced to get it out ;-)

Strangely I have to force the commit because of a pre-commit hook check error in part of the code I did not touch:

```bash
black....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

traffic/data/eurocontrol/b2b/pkcs12.py:59:43: error: Argument 1 to
"from_cryptography_key" of "PKey" has incompatible type "Optional[Any]";
expected "Union[DSAPrivateKey, DSAPublicKey, RSAPrivateKey, RSAPublicKey]"
            crypto.PKey.from_cryptography_key(private_key)
                                              ^
Found 1 error in 1 file (checked 1 source file)

isort....................................................................Failed
- hook id: isort
- exit code: 1

Executable `isort` not found
```
