### PR TITLE
Error fix in flight.py

### DIFF
--- a/traffic/core/flight.py
+++ b/traffic/core/flight.py
@@ -1563,7 +1563,7 @@ class Flight(
             features = default_angle_features
 
         if isinstance(features, str):
-            features = [features]
+            features = [features].astype(float)
 
         reset = self.reset_index(drop=True)
 
@@ -1575,9 +1575,7 @@ class Flight(
             idx = ~series.isnull()
             result_dict[f"{feature}_unwrapped"] = pd.Series(
                 np.degrees(
-                    np.unwrap(
-                        np.radians(series.astype(float).loc[idx])
-                    )  # type: ignore
+                    np.unwrap(np.radians(series.loc[idx]))  # type: ignore
                 ),
                 index=series.loc[idx].index,
             )

--- a/traffic/core/flight.py
+++ b/traffic/core/flight.py
@@ -1575,7 +1575,9 @@ class Flight(
             idx = ~series.isnull()
             result_dict[f"{feature}_unwrapped"] = pd.Series(
                 np.degrees(
-                    np.unwrap(np.radians(series.loc[idx]))  # type: ignore
+                    np.unwrap(
+                        np.radians(series.astype(float).loc[idx])
+                    )  # type: ignore
                 ),
                 index=series.loc[idx].index,
             )


### PR DESCRIPTION
This pull request fixes an error in the `Flight.unwrap()` method, where we get the following exceptions:

```
AttributeError: 'float' object has no attribute 'radians'
The above exception was the direct cause of the following exception:

TypeError: loop of ufunc does not support argument 0 of type float which has no callable radians method
```