### PR TITLE
Add ".pickle" to read suffixes

### DIFF
--- a/traffic/core/mixins.py
+++ b/traffic/core/mixins.py
@@ -72,7 +72,7 @@ class DataFrameMixin(object):
         >>> t = Traffic.from_file("data/sample_opensky.pkl")
         """
         path = Path(filename)
-        if ".pkl" in path.suffixes:
+        if ".pkl" in path.suffixes or ".pickle" in path.suffixes:
             return cls(pd.read_pickle(path, **kwargs))
         if ".parquet" in path.suffixes:
             return cls(pd.read_parquet(path, **kwargs))


### PR DESCRIPTION
As proposed in the pickle docs ".pickle" should be the preferred way to save pickle files. This commit adds the ".pickle" suffixes in the mixins.py file to be able to read .pickle files.