### PR TITLE
Change behaviour of logging library and do not use the root logger.

### DIFF
--- a/traffic/__init__.py
+++ b/traffic/__init__.py
@@ -15,6 +15,11 @@ from . import drawing  # noqa: F401
 __version__ = importlib_metadata.version("traffic")  # type: ignore
 __all__ = ["config_dir", "config_file", "cache_dir"]
 
+logger_traffic = logging.getLogger("traffic")
+logger_traffic.setLevel(logging.WARNING)
+
+logger = logging.getLogger(__name__)
+
 # -- Configuration management --
 
 config_dir = Path(user_config_dir("traffic"))
@@ -80,7 +85,7 @@ if cache_purge_cfg != "" and not cache_no_expire:
     )
 
     if len(purgeable) > 0:
-        logging.warn(
+        logger.warn(
             f"Removing {len(purgeable)} cache files older than {cache_purge}"
         )
         for path in purgeable:
@@ -97,13 +102,13 @@ _enabled_list = ",".join(_enabled_plugins_raw.split("\n")).split(",")
 _selected = set(s.replace("-", "").strip().lower() for s in _enabled_list)
 _selected -= {""}
 
-logging.info(f"Selected plugins: {_selected}")
+logger.info(f"Selected plugins: {_selected}")
 
 if "TRAFFIC_NOPLUGIN" not in os.environ.keys():  # coverage: ignore
     for entry_point in pkg_resources.iter_entry_points("traffic.plugins"):
         if entry_point.name.replace("-", "").lower() in _selected:
             handle = entry_point.load()
-            logging.info(f"Loading plugin: {handle.__name__}")
+            logger.info(f"Loading plugin: {handle.__name__}")
             load = getattr(handle, "_onload", None)
             if load is not None:
                 load()

--- a/traffic/algorithms/cpa.py
+++ b/traffic/algorithms/cpa.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
     from ..core import Traffic
 
+logger = logging.getLogger(__name__)
+
 
 def combinations(
     t: "Traffic", lateral_separation: float, vertical_separation: float
@@ -159,7 +161,7 @@ def closest_point_of_approach(
     from cartopy import crs
 
     if projection is None:
-        logging.warn("Defaulting to projection EuroPP()")
+        logger.warn("Defaulting to projection EuroPP()")
         projection = crs.EuroPP()
 
     if isinstance(projection, crs.Projection):

--- a/traffic/algorithms/navigation.py
+++ b/traffic/algorithms/navigation.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from ..data.basic.airports import Airports  # noqa: 401
     from ..data.basic.navaid import Navaids  # noqa: 401
 
+logger = logging.getLogger(__name__)
+
 
 class PointMergeParams(TypedDict):
     point_merge: str | PointMixin
@@ -885,11 +887,11 @@ class NavigationFeatures:
 
         if isinstance(point_merge, str):
             if navaids_extent is None:
-                logging.warn(msg)
+                logger.warn(msg)
                 return None
             point_merge = navaids_extent.global_get(point_merge)  # type: ignore
             if point_merge is None:
-                logging.warn("Navaid for point_merge not found")
+                logger.warn("Navaid for point_merge not found")
                 return None
 
         if secondary_point is None:
@@ -897,11 +899,11 @@ class NavigationFeatures:
 
         if isinstance(secondary_point, str):
             if navaids_extent is None:
-                logging.warn(msg)
+                logger.warn(msg)
                 return None
             secondary_point = navaids_extent.global_get(secondary_point)
             if secondary_point is None:
-                logging.warn("Navaid for secondary_point not found")
+                logger.warn("Navaid for secondary_point not found")
                 return None
 
         if airport is not None:

--- a/traffic/console/cache.py
+++ b/traffic/console/cache.py
@@ -4,6 +4,8 @@ from typing import List
 
 from . import dispatch_open
 
+logger = logging.getLogger(__name__)
+
 
 def main(args_list: List[str]) -> None:
 
@@ -35,5 +37,5 @@ def main(args_list: List[str]) -> None:
         print(cache_dir)
 
     if args.open:
-        logging.info("Open cache directory {}".format(cache_dir))
+        logger.info("Open cache directory {}".format(cache_dir))
         dispatch_open(cache_dir)

--- a/traffic/console/config.py
+++ b/traffic/console/config.py
@@ -4,6 +4,8 @@ from typing import List
 
 from . import dispatch_open
 
+logger = logging.getLogger(__name__)
+
 
 def main(args_list: List[str]) -> None:
 
@@ -43,9 +45,9 @@ def main(args_list: List[str]) -> None:
         print(config_dir)
 
     if args.edit:
-        logging.info("Open configuration file {}".format(config_file))
+        logger.info("Open configuration file {}".format(config_file))
         dispatch_open(config_file)
 
     if args.open:
-        logging.info("Open configuration directory {}".format(config_file))
+        logger.info("Open configuration directory {}".format(config_file))
         dispatch_open(config_dir)

--- a/traffic/core/__init__.py
+++ b/traffic/core/__init__.py
@@ -2,7 +2,7 @@
 """
 It is crucial that the imports do not change order,
 hence the following line:
-isort:skip_file 
+isort:skip_file
 """
 
 import logging
@@ -31,10 +31,13 @@ __all__ = [
     "faulty_flight",
 ]
 
+logger_traffic = logging.getLogger("traffic")
+logger_traffic.setLevel(logging.WARNING)
+
 
 def loglevel(mode: str) -> None:
-    logger = logging.getLogger()
-    logger.setLevel(getattr(logging, mode))
+    logger_traffic = logging.getLogger("traffic")
+    logger_traffic.setLevel(getattr(logging, mode))
 
 
 def faulty_flight(exc: Optional[TracebackType] = None) -> Dict[str, Any]:

--- a/traffic/core/distance.py
+++ b/traffic/core/distance.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from .mixins import PointMixin  # noqa: F401
     from .structure import Airport
 
+logger = logging.getLogger(__name__)
+
 
 def closest_point(
     data: pd.DataFrame,
@@ -79,7 +81,7 @@ def guess_airport(
     airport.distance = airport_data.distance  # type: ignore
 
     if warning_distance is not None and airport.distance > warning_distance:
-        logging.warning(
+        logger.warning(
             f"Closest airport is more than {warning_distance*1e-3}km away "
             f" (distance={airport.distance})"
         )

--- a/traffic/core/flight.py
+++ b/traffic/core/flight.py
@@ -68,6 +68,8 @@ if TYPE_CHECKING:
     from .structure import Navaid  # noqa: F401
     from .traffic import Traffic  # noqa: F401
 
+logger = logging.getLogger(__name__)
+
 
 class Entry(TypedDict, total=False):
     timestamp: pd.Timestamp
@@ -818,7 +820,7 @@ class Flight(
         if len(tmp) == 1:
             return tmp[0]  # type: ignore
         if warn:
-            logging.warning(
+            logger.warning(
                 f"Several {field}s for one flight, consider splitting"
             )
         return set(tmp)
@@ -1174,7 +1176,7 @@ class Flight(
         df = self.data.set_index("timestamp")
         if index not in df.index:
             id_ = getattr(self, "flight_id", self.callsign)
-            logging.warning(f"No index {index} for flight {id_}")
+            logger.warning(f"No index {index} for flight {id_}")
             return None
         return Position(df.loc[index])
 
@@ -2537,7 +2539,7 @@ class Flight(
             id_ = self.flight_id
             if id_ is None:
                 id_ = self.callsign
-            logging.warning(f"No data on Impala for flight {id_}.")
+            logger.warning(f"No data on Impala for flight {id_}.")
             return self
 
         def fail_silent() -> "Flight":

--- a/traffic/core/lazy.py
+++ b/traffic/core/lazy.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
     from .traffic import Traffic  # noqa: F401
 
+logger = logging.getLogger(__name__)
+
 
 class FaultCatcher:
     flag: bool = False
@@ -256,7 +258,7 @@ class LazyTraffic:
 
     def __getattr__(self, name: str) -> Any:
         if hasattr(self.wrapped_t, name):
-            logging.warning(
+            logger.warning(
                 ".eval() has been automatically appended for you.\n"
                 "Check the documentation for more options."
             )
@@ -335,9 +337,9 @@ It should be safe to create a proper named function and pass it to filter_if.
             op_idx = LazyLambda(f.__name__, idx_name, *args, **kwargs)
 
             if any(is_lambda(arg) for arg in args):
-                logging.warning(msg.format(method=f.__name__))
+                logger.warning(msg.format(method=f.__name__))
             if any(is_lambda(arg) for arg in kwargs.values()):
-                logging.warning(msg.format(method=f.__name__))
+                logger.warning(msg.format(method=f.__name__))
 
             return LazyTraffic(
                 lazy.wrapped_t,
@@ -374,9 +376,9 @@ It should be safe to create a proper named function and pass it to filter_if.
             op_idx = LazyLambda(f.__name__, idx_name, *args, **kwargs)
 
             if any(is_lambda(arg) for arg in args):
-                logging.warning(msg.format(method=f.__name__))
+                logger.warning(msg.format(method=f.__name__))
             if any(is_lambda(arg) for arg in kwargs.values()):
-                logging.warning(msg.format(method=f.__name__))
+                logger.warning(msg.format(method=f.__name__))
 
             return LazyTraffic(wrapped_t, [op_idx])
 

--- a/traffic/core/logging.py
+++ b/traffic/core/logging.py
@@ -1,10 +1,12 @@
 import logging
 
-logging.warning(
+logger = logging.getLogger(__name__)
+
+logger.warning(
     "Prefer `from traffic.core import loglevel`", DeprecationWarning
 )
 
 
 def loglevel(mode: str) -> None:
-    logger = logging.getLogger()
-    logger.setLevel(getattr(logging, mode))
+    logger_traffic = logging.getLogger("traffic")
+    logger_traffic.setLevel(getattr(logging, mode))

--- a/traffic/core/traffic.py
+++ b/traffic/core/traffic.py
@@ -63,6 +63,8 @@ TrafficTypeVar = TypeVar("TrafficTypeVar", bound="Traffic")
 # The thing is that Iterable[str] causes issue sometimes...
 IterStr = Union[List[str], Set[str]]
 
+logger = logging.getLogger(__name__)
+
 
 class Traffic(HBoxMixin, GeographyMixin):
     """
@@ -168,7 +170,7 @@ class Traffic(HBoxMixin, GeographyMixin):
             return tentative.rename(columns=rename_columns)
 
         path = Path(filename)
-        logging.warning(f"{path.suffixes} extension is not supported")
+        logger.warning(f"{path.suffixes} extension is not supported")
         return None
 
     # --- Special methods ---
@@ -305,7 +307,7 @@ class Traffic(HBoxMixin, GeographyMixin):
             )
 
         if not isinstance(index, str):  # List[str], Set[str], Iterable[str]
-            logging.debug("Selecting flights from a list of identifiers")
+            logger.debug("Selecting flights from a list of identifiers")
             subset = repr(list(index))
             query_str = f"callsign in {subset} or icao24 in {subset}"
             if "flight_id" in self.data.columns:
@@ -743,7 +745,7 @@ class Traffic(HBoxMixin, GeographyMixin):
     @property_cache
     def aircraft(self) -> Set[str]:
         """Return all the different icao24 aircraft ids in the DataFrame"""
-        logging.warning("Use .icao24", DeprecationWarning)
+        logger.warning("Use .icao24", DeprecationWarning)
         return set(self.data.icao24)
 
     @property_cache

--- a/traffic/data/__init__.py
+++ b/traffic/data/__init__.py
@@ -104,6 +104,8 @@ nmb2b_version = config.get("nmb2b", "version", fallback="25.0.0")
 
 _cached_imports: Dict[str, Any] = dict()
 
+logger = logging.getLogger(__name__)
+
 
 def __getattr__(name: str) -> Any:
 
@@ -295,7 +297,7 @@ def __getattr__(name: str) -> Any:
         from .eurocontrol.b2b import NMB2B
 
         if pkcs12_filename != "" and pkcs12_password != "":
-            logging.debug(f"pcks12_filename: {pkcs12_filename}")
+            logger.debug(f"pcks12_filename: {pkcs12_filename}")
             nm_b2b = NMB2B(
                 getattr(NMB2B, nmb2b_mode),
                 nmb2b_version,

--- a/traffic/data/adsb/decode.py
+++ b/traffic/data/adsb/decode.py
@@ -41,6 +41,8 @@ else:
 
 Decoder = TypeVar("Decoder", bound="ModeS_Decoder")
 
+logger = logging.getLogger(__name__)
+
 
 def next_msg(chunk_it: Iterator[bytes]) -> Iterator[bytes]:
     data = b""
@@ -356,7 +358,7 @@ class Aircraft(object):
         )
         speed, track, _, speed_type, *_ = pms.adsb.surface_velocity(msg)
         if speed_type != "GS":
-            logging.warn(f"Ground airspeed for aircraft {self.icao24}")
+            logger.warn(f"Ground airspeed for aircraft {self.icao24}")
 
         # This helps updating current representations
         self.spd = speed
@@ -964,7 +966,7 @@ class ModeS_Decoder:
             reference = airports[reference]
 
         if reference is None:
-            logging.warning(
+            logger.warning(
                 "No valid reference position provided. Fallback to (0, 0)"
             )
             lat0, lon0 = 0.0, 0.0
@@ -1002,7 +1004,7 @@ class ModeS_Decoder:
         def decorate(
             function: Callable[[Decoder], None]
         ) -> Callable[[Decoder], None]:
-            logging.info(f"Schedule {function.__name__} with {frequency}")
+            logger.info(f"Schedule {function.__name__} with {frequency}")
             heapq.heappush(
                 cls.timer_functions,
                 (now + frequency, frequency, function),
@@ -1012,7 +1014,7 @@ class ModeS_Decoder:
         return decorate
 
     def expire_aircraft(self) -> None:
-        logging.info("Running expire_aircraft")
+        logger.info("Running expire_aircraft")
 
         now = pd.Timestamp("now", tz="utc")
 
@@ -1038,7 +1040,7 @@ class ModeS_Decoder:
             del self.acs[icao]
 
     def on_new_aircraft(self, icao: str) -> None:
-        logging.info(f"New aircraft {icao}")
+        logger.info(f"New aircraft {icao}")
 
     @classmethod
     def from_file(
@@ -1252,7 +1254,7 @@ class ModeS_Decoder:
 
                 now = pd.Timestamp("now", tz="utc")
                 operation(decoder)
-                logging.info(f"Schedule {operation.__name__} at {now + delta}")
+                logger.info(f"Schedule {operation.__name__} at {now + delta}")
                 heapq.heappush(
                     cls.timer_functions, (now + delta, delta, operation)
                 )
@@ -1563,7 +1565,7 @@ class ModeS_Decoder:
                 self[elt["icao24"]] for elt in self.aircraft
             )
         except ValueError as e:
-            logging.warning(e)
+            logger.warning(e)
             return None
 
     def __getitem__(self, icao: str) -> Optional[Flight]:

--- a/traffic/data/adsb/opensky.py
+++ b/traffic/data/adsb/opensky.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from cartopy.mpl.geoaxes import GeoAxesSubplot
     from matplotlib.artist import Artist
 
+logger = logging.getLogger(__name__)
+
 
 class Coverage(object):
     """Plots the output of the coverage json."""
@@ -238,7 +240,7 @@ class OpenSky(Impala):
                 c.json()["states"], columns=self._json_columns
             )
         except Exception:
-            logging.warning("Error in received data, retrying in 10 seconds")
+            logger.warning("Error in received data, retrying in 10 seconds")
             time.sleep(10)
             return self.api_states(own, bounds)
 

--- a/traffic/data/adsb/opensky_impala.py
+++ b/traffic/data/adsb/opensky_impala.py
@@ -23,6 +23,8 @@ from ...core.time import round_time, split_times, timelike, to_datetime
 from ...core.types import ProgressbarType
 from .raw_data import RawData
 
+logger = logging.getLogger(__name__)
+
 
 class ImpalaError(Exception):
     pass
@@ -111,7 +113,7 @@ class Impala(object):
     @staticmethod
     def _read_cache(cachename: Path) -> None | pd.DataFrame:
 
-        logging.info("Reading request in cache {}".format(cachename))
+        logger.info("Reading request in cache {}".format(cachename))
         with cachename.open("r") as fh:
             s = StringIO()
             count = 0
@@ -235,7 +237,7 @@ class Impala(object):
             # for instance:
             #    "ssh -W data.opensky-network.org:2230 proxy_machine"
             # or "connect.exe -H proxy_ip:proxy_port %h %p"
-            logging.info(f"Using ProxyCommand: {self.proxy_command}")
+            logger.info(f"Using ProxyCommand: {self.proxy_command}")
             extra_args["sock"] = paramiko.ProxyCommand(self.proxy_command)
 
         client.connect(
@@ -268,10 +270,10 @@ class Impala(object):
             cachename.unlink()
 
         if not cachename.exists():
-            logging.info("Sending request: {}".format(request))
+            logger.info("Sending request: {}".format(request))
 
             if not self.connected:
-                logging.info("Connecting the database")
+                logger.info("Connecting the database")
                 self._connect()
 
             # bug fix for when we write a request with """ starting with \n
@@ -280,7 +282,7 @@ class Impala(object):
             # avoid messing lines in the cache file
             time.sleep(0.1)
             total = ""
-            logging.info("Will be writing into {}".format(cachename))
+            logger.info("Will be writing into {}".format(cachename))
             while len(total) == 0 or total[-10:] != ":21000] > ":
                 b = self.stdout.channel.recv(256)
                 total += b.decode()
@@ -290,13 +292,13 @@ class Impala(object):
             # (and my) best efforts to handle exceptions.
             # If data is streamed directly into the cache file, it is hard to
             # detect that it is corrupted and should be removed/overwritten.
-            logging.info("Opening {}".format(cachename))
+            logger.info("Opening {}".format(cachename))
             with cachename.open("w") as fh:
                 if columns is not None:
                     fh.write(re.sub(", ", "\t", columns))
                     fh.write("\n")
                 fh.write(total)
-            logging.info("Closing {}".format(cachename))
+            logger.info("Closing {}".format(cachename))
 
         return self._read_cache(cachename)
 
@@ -414,7 +416,7 @@ class Impala(object):
         sequence = list(split_times(start, stop, date_delta))
 
         for bt, at, bh, ah in progressbar(sequence):
-            logging.info(
+            logger.info(
                 f"Sending request between time {bt} and {at} "
                 f"and hour {bh} and {ah}"
             )
@@ -589,7 +591,7 @@ class Impala(object):
 
         for bt, at, before_day, after_day in progressbar(sequence):
 
-            logging.info(
+            logger.info(
                 f"Sending request between time {bt} and {at} "
                 f"and day {before_day} and {after_day}"
             )
@@ -909,7 +911,7 @@ class Impala(object):
 
         for bt, at, bh, ah in progressbar(sequence):
 
-            logging.info(
+            logger.info(
                 f"Sending request between time {bt} and {at} "
                 f"and hour {bh} and {ah}"
             )
@@ -1288,7 +1290,7 @@ class Impala(object):
 
         for bt, at, bh, ah in progressbar(sequence):
 
-            logging.info(
+            logger.info(
                 f"Sending request between time {bt} and {at} "
                 f"and hour {bh} and {ah}"
             )

--- a/traffic/data/basic/aircraft.py
+++ b/traffic/data/basic/aircraft.py
@@ -18,6 +18,8 @@ import pandas as pd
 
 from ...core.mixins import DataFrameMixin, FormatMixin
 
+logger = logging.getLogger(__name__)
+
 json_path = Path(__file__).parent / "patterns.json"
 
 registration_patterns = list(
@@ -227,7 +229,7 @@ class Aircraft(DataFrameMixin):
         """
         from .. import session
 
-        logging.warning("Downloading OpenSky aircraft database")
+        logger.warning("Downloading OpenSky aircraft database")
         file_url = (
             "https://opensky-network.org/datasets/metadata/aircraftDatabase.csv"
         )
@@ -255,7 +257,7 @@ class Aircraft(DataFrameMixin):
     def opensky_db(self) -> pd.DataFrame:
         if not (self.cache_dir / "opensky_db.pkl").exists():
             self.download_opensky()
-        logging.info("Loading OpenSky aircraft database")
+        logger.info("Loading OpenSky aircraft database")
         return pd.read_pickle(self.cache_dir / "opensky_db.pkl")
 
     def __getitem__(self: T, name: str | list[str]) -> None | T:

--- a/traffic/data/basic/airways.py
+++ b/traffic/data/basic/airways.py
@@ -11,6 +11,8 @@ from shapely.geometry.base import BaseGeometry
 from ...core.mixins import GeoDBMixin
 from ...core.structure import Navaid, Route
 
+logger = logging.getLogger(__name__)
+
 __github_url = "https://raw.githubusercontent.com/"
 base_url = __github_url + "xoolive/traffic/master/data/navdata"
 
@@ -113,7 +115,7 @@ class Airways(GeoDBMixin):
         if not (self.cache_dir / "traffic_airways.pkl").exists():
             self.download_data()
         else:
-            logging.info("Loading airways database")
+            logger.info("Loading airways database")
             self._data = pd.read_pickle(self.cache_dir / "traffic_airways.pkl")
 
         if self._data is not None:

--- a/traffic/data/basic/navaid.py
+++ b/traffic/data/basic/navaid.py
@@ -11,6 +11,8 @@ import pandas as pd
 from ...core.mixins import GeoDBMixin
 from ...core.structure import Navaid, NavaidTuple
 
+logger = logging.getLogger(__name__)
+
 __github_url = "https://raw.githubusercontent.com/"
 base_url = __github_url + "xoolive/traffic/master/data/navdata"
 
@@ -203,7 +205,7 @@ class Navaids(GeoDBMixin):
         if not (self.cache_dir / "traffic_navaid.pkl").exists():
             self.download_data()
         else:
-            logging.info("Loading navaid database")
+            logger.info("Loading navaid database")
             self._data = pd.read_pickle(self.cache_dir / "traffic_navaid.pkl")
 
         if self._data is not None:

--- a/traffic/data/eurocontrol/aixm/navpoints.py
+++ b/traffic/data/eurocontrol/aixm/navpoints.py
@@ -14,6 +14,8 @@ from ...basic.navaid import Navaids
 # https://github.com/python/mypy/issues/2511
 T = TypeVar("T", bound="AIXMNavaidParser")
 
+logger = logging.getLogger(__name__)
+
 
 class AIXMNavaidParser(Navaids):
     name: str = "aixm_navaids"
@@ -49,7 +51,7 @@ class AIXMNavaidParser(Navaids):
             if self._extensions is not None:
                 self._extensions.to_pickle(extension_file)
         else:
-            logging.info("Loading aixm points database")
+            logger.info("Loading aixm points database")
 
             self._extensions = pd.read_pickle(extension_file)
 
@@ -72,7 +74,7 @@ class AIXMNavaidParser(Navaids):
             if self._extensions is not None:
                 self._extensions.to_pickle(extension_file)
         else:
-            logging.info("Loading aixm points database")
+            logger.info("Loading aixm points database")
             self._data = pd.read_pickle(cache_file)
 
         return self._data

--- a/traffic/data/eurocontrol/b2b/pkcs12.py
+++ b/traffic/data/eurocontrol/b2b/pkcs12.py
@@ -30,6 +30,8 @@ try:
 except ImportError:
     from ssl import PROTOCOL_SSLv23 as ssl_protocol
 
+logger = logging.getLogger(__name__)
+
 
 def check_cert_not_after(certificate: Certificate) -> None:
     if certificate.not_valid_after < datetime.utcnow():
@@ -50,7 +52,7 @@ def create_pyopenssl_sslcontext(
     check_cert_not_after(certificate)
     ssl_context = PyOpenSSLContext(ssl_protocol)
     ssl_context._ctx.use_certificate(crypto.X509.from_cryptography(certificate))
-    logging.info(
+    logger.info(
         f"Certificate found with subject {certificate.subject}, "
         f"expire on {certificate.not_valid_after}"
     )

--- a/traffic/data/eurocontrol/ddr/airspaces.py
+++ b/traffic/data/eurocontrol/ddr/airspaces.py
@@ -14,6 +14,8 @@ from ....core.airspace import Airspaces
 
 A = TypeVar("A", bound="NMAirspaceParser")
 
+logger = logging.getLogger(__name__)
+
 
 class NMAirspaceParser(Airspaces):
 
@@ -79,7 +81,7 @@ class NMAirspaceParser(Airspaces):
         )
 
     def read_are(self, filename: Path) -> None:
-        logging.info(f"Reading ARE file {filename}")
+        logger.info(f"Reading ARE file {filename}")
         nb_points = 0
         area_coords: List[Tuple[float, float]] = list()
         name = None
@@ -106,7 +108,7 @@ class NMAirspaceParser(Airspaces):
                 self.polygons[name] = orient(shape(geometry), -1)
 
     def read_sls(self, filename: Path) -> None:
-        logging.info(f"Reading SLS file {filename}")
+        logger.info(f"Reading SLS file {filename}")
         with filename.open("r") as fh:
             for line in fh.readlines():
                 name, _, polygon, lower, upper = line.split()
@@ -120,7 +122,7 @@ class NMAirspaceParser(Airspaces):
                 )
 
     def read_spc(self, filename: Path) -> Iterator[dict[str, Any]]:
-        logging.info(f"Reading SPC file {filename}")
+        logger.info(f"Reading SPC file {filename}")
         with open(filename, "r") as fh:
             for line in fh.readlines():
                 letter, component, *after = line.split(";")

--- a/traffic/data/eurocontrol/ddr/so6.py
+++ b/traffic/data/eurocontrol/ddr/so6.py
@@ -46,6 +46,8 @@ from ....core.time import time_or_delta, timelike, to_datetime
 if TYPE_CHECKING:
     from cartopy.crs import Projection
 
+logger = logging.getLogger(__name__)
+
 
 def _prepare_libarchive() -> None:  # coverage: ignore
     """
@@ -66,12 +68,12 @@ def _prepare_libarchive() -> None:  # coverage: ignore
     try:
         result = subprocess.check_output(command)
     except Exception as e:
-        logging.error("Could not lookup 'libarchive' package info", e)
+        logger.error("Could not lookup 'libarchive' package info", e)
 
     info = json.loads(result)
     installed_versions = info[0]["installed"]
     if len(installed_versions) == 0:
-        logging.warning("libarchive is not currently installed via Brew")
+        logger.warning("libarchive is not currently installed via Brew")
         return
 
     version = installed_versions[0]["version"]

--- a/traffic/data/faa/__init__.py
+++ b/traffic/data/faa/__init__.py
@@ -12,6 +12,8 @@ from ... import cache_dir, cache_expiration
 
 __all__ = list(p.stem[1:] for p in Path(__file__).parent.glob("_[a-z]*py"))
 
+logger = logging.getLogger(__name__)
+
 
 class ADDS_FAA_OpenData:
 
@@ -28,7 +30,7 @@ class ADDS_FAA_OpenData:
     def download_data(self) -> None:
         from .. import session
 
-        logging.warning(
+        logger.warning(
             f"Downloading data from {self.website}. Please check terms of use."
         )
         c = session.get(self.json_url)

--- a/traffic/data/faa/_airspace_boundary.py
+++ b/traffic/data/faa/_airspace_boundary.py
@@ -11,6 +11,8 @@ from shapely.ops import orient
 from ...core.airspace import Airspace, Airspaces, ExtrudedPolygon
 from . import ADDS_FAA_OpenData
 
+logger = logging.getLogger(__name__)
+
 
 class Airspace_Boundary(ADDS_FAA_OpenData, Airspaces):
 
@@ -68,7 +70,7 @@ class Airspace_Boundary(ADDS_FAA_OpenData, Airspaces):
             )
 
             if not airspace.shape.is_valid:
-                logging.warning(f"Invalid shape part {name}, skipping...")
+                logger.warning(f"Invalid shape part {name}, skipping...")
                 continue
 
             if name in airspaces:

--- a/traffic/plugins/bluesky.py
+++ b/traffic/plugins/bluesky.py
@@ -8,6 +8,8 @@ from traffic.core.aero import vtas2cas
 from traffic.core.time import timelike
 from traffic.data import aircraft
 
+logger = logging.getLogger(__name__)
+
 
 def fmt_timedelta(x: pd.Timestamp) -> str:
     return (
@@ -111,7 +113,7 @@ def to_bluesky(
                     f"{v.track} {v.cas} {v.vertical_rate}\n"
                 )
 
-        logging.info(f"Scenario file {filename} written")
+        logger.info(f"Scenario file {filename} written")
 
 
 def _onload() -> None:

--- a/traffic/plugins/cesiumjs.py
+++ b/traffic/plugins/cesiumjs.py
@@ -12,6 +12,8 @@ from ..core import Flight, Traffic
 from ..core.time import timelike, to_datetime
 from ..data import SO6
 
+logger = logging.getLogger(__name__)
+
 
 class _CZML_Params:
     default_time_multiplier = 100
@@ -132,7 +134,7 @@ def to_czml(
     with filename.open("w") as fh:
         json.dump(export, fh, indent=2)
 
-    logging.info(f"Scenario file {filename} written")
+    logger.info(f"Scenario file {filename} written")
 
 
 def _onload() -> None:

--- a/traffic/plugins/kepler.py
+++ b/traffic/plugins/kepler.py
@@ -10,6 +10,8 @@ from shapely.wkt import dumps
 
 from ..core import Airspace, Flight, Traffic
 
+logger = logging.getLogger(__name__)
+
 
 def flight_kepler(flight: "Flight") -> Dict[str, Any]:
     return dict(
@@ -39,7 +41,7 @@ def airspace_kepler(airspace: "Airspace") -> Dict[str, Any]:
 
 def traffic_kepler(traffic: "Traffic") -> pd.DataFrame:
     if traffic.flight_ids is None:
-        logging.warning("assign_id() has been appended for you")
+        logger.warning("assign_id() has been appended for you")
         traffic = cast("Traffic", traffic.assign_id().eval())
     return pd.DataFrame.from_records(
         [


### PR DESCRIPTION
Please double check it. I now made it the following way (as far as I understand it, please question every statement):

- There is a new logger for the whole library named `traffic` (Not 100% sure if it is need in both `__init__` files but it also does not harm) with log level set to `logging.WARNING`
- In every file there is a `logging.getLogger(__name__)` and the logging messages are written to that logger. (in debug look into `logging.root.manager.loggerDict`)
    - As they are child loggers of the `traffic` logger it is later sufficient to add Handlers to the `root` or `traffic` logger and it also handles all the others.
    - Not sure if it better to only have the child loggers `traffic.core`, `traffic.plugins`, … and rely on the Formatter of the user to print the filename (otherwise he does not really know where the log message comes from).
- I did not change anything in the `scrips` folder as they are not really interfering with the library and are standalone.

Signed-off-by: q-wertz <clemens.sonnleitner@web.de>