### PR TITLE
Support threshold coordinate projection via compute_xy() interface

### DIFF
--- a/src/traffic/data/basic/runways.py
+++ b/src/traffic/data/basic/runways.py
@@ -23,7 +23,13 @@ from shapely.ops import linemerge
 
 from ... import cache_expiration
 from ...core.geodesy import bearing, destination
-from ...core.mixins import DataFrameMixin, HBoxMixin, PointMixin, ShapelyMixin
+from ...core.mixins import (
+    DataFrameMixin,
+    HBoxMixin,
+    PointMixin,
+    ShapelyMixin,
+    GeographyMixin,
+)
 
 if TYPE_CHECKING:
     import altair as alt
@@ -50,7 +56,7 @@ class Threshold(ThresholdTuple, PointMixin):
 RunwaysType = Dict[str, List[Tuple[Threshold, Threshold]]]
 
 
-class RunwayAirport(HBoxMixin, ShapelyMixin, DataFrameMixin):
+class RunwayAirport(HBoxMixin, ShapelyMixin, GeographyMixin):
     def __init__(
         self,
         data: Optional[pd.DataFrame] = None,


### PR DESCRIPTION
This PR intends to add support for projecting threshold coordinates using the common `compute_xy()` interface.

However, currently the `RunwayAirport()` constructor [just swallows](https://github.com/xoolive/traffic/blob/master/src/traffic/data/basic/runways.py#L59) the enriched DataFrame passed to it at the end of [`compute_xy()`](https://github.com/xoolive/traffic/blob/master/src/traffic/core/mixins.py#L527).
Consequently, the following code returns `None`:

```python
>>> from traffic.data import airports
>>> airport = airports["CDG"]
>>> airport.runways.compute_xy()
None
```

The DataFrame containing the projection can be accessed via
```python
>>> airport.runways.compute_xy()._data
    latitude  longitude     bearing name            x            y
0  48.995701    2.55274   85.293092  08L  -722.812433 -1562.345186
1  48.998798    2.61018  265.336441  26R  3480.306639 -1216.826055
2  48.992901    2.56566   85.263542  08R   222.653855 -1873.773350
3  48.994900    2.60243  265.291290  26L  2913.454043 -1650.716705
4  49.024700    2.52489   85.264343  09L -2759.230258  1663.306856
5  49.026699    2.56169  265.292128  27R   -67.826773  1884.919854
6  49.020599    2.51306   85.267941  09R -3624.711297  1207.753756
7  49.023701    2.57029  265.311147  27L   561.147681  1551.500392
```

I am currently not sure how to propagate the results of the projection back up the runway/threshold data stream.