### PR TITLE
Improve support for SCAT dataset

### DIFF
--- a/src/traffic/data/datasets/scat.py
+++ b/src/traffic/data/datasets/scat.py
@@ -65,7 +65,8 @@ class SCAT:
                     """
                 timestamp = @pd.to_datetime(timestamp, utc=True, format="mixed")
                 flight_id = @flight_id
-                """
+                """,
+                    engine="python",
                 )
             )
 
@@ -76,7 +77,8 @@ class SCAT:
                     """
                 timestamp = @pd.to_datetime(timestamp, utc=True, format="mixed")
                 flight_id = @flight_id
-                """
+                """,
+                    engine="python",
                 )
             )
 
@@ -94,7 +96,8 @@ class SCAT:
             callsign = @fpl_base['callsign']
             flight_id = @flight_id
             icao24 = "000000"
-            """
+            """,
+                    engine="python",
                 )
             )
             return Entry(Flight(df), flight_plan, clearance)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -13,8 +13,48 @@ def test_scat() -> None:
 def test_scat_waypoints() -> None:
     s = SCAT("scat20161015_20161021.zip", nflights=10, include_waypoints=True)
     assert isinstance(s.waypoints, pd.DataFrame)
+    assert len(s.waypoints) == 15871
+    assert set(s.waypoints.columns) == {
+        "latitude",
+        "longitude",
+        "name",
+        "center",
+    }
+    aa212 = s.waypoints[s.waypoints["name"] == "AA212"]
+    assert len(aa212) == 1
+    assert aa212["latitude"].item() == 58.4902778
+    assert aa212["longitude"].item() == 14.4866667
+    assert aa212["center"].item() == "ESMM"
+
+    # KERAX is present for both centers
+    kerax = s.waypoints[s.waypoints["name"] == "KERAX"]
+    assert set(kerax["center"].values) == {"ESMM", "ESOS"}
+    assert kerax.iloc[0]["latitude"] == kerax.iloc[1]["latitude"] == 50.475
+    assert kerax.iloc[0]["longitude"] == kerax.iloc[1]["longitude"] == 9.5819444
 
 
 def test_scat_weather() -> None:
     s = SCAT("scat20161015_20161021.zip", nflights=10, include_weather=True)
     assert isinstance(s.weather, pd.DataFrame)
+    assert not s.weather.isna().any().max()
+    assert len(s.weather) == 1519310
+    assert set(s.weather.columns) == {
+        "altitude",
+        "latitude",
+        "longitude",
+        "temperature",
+        "timestamp",
+        "wind_direction",
+        "wind_speed",
+    }
+    assert isinstance(s.weather["timestamp"].dtype, pd.DatetimeTZDtype)
+
+    # compare measurement for a specific timestamp
+    ts = pd.to_datetime("2016-10-14 10:30:00+00:00")  # noqa: F841
+    measurement = s.weather.query(
+        "timestamp == @ts & altitude == 50 & latitude == 42.5 & longitude == 60"
+    )
+    assert len(measurement) == 1
+    assert measurement["temperature"].item() == 4
+    assert measurement["wind_direction"].item() == 166
+    assert measurement["wind_speed"].item() == 16

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,8 +1,20 @@
 from traffic.data.datasets.scat import SCAT
 
+import pandas as pd
+
 
 def test_scat() -> None:
     s = SCAT("scat20161015_20161021.zip", nflights=10)
     assert len(s.traffic) == 10
     assert s.flight_plans.flight_id.nunique() == 10
     assert s.clearances.flight_id.nunique() == 10
+
+
+def test_scat_waypoints() -> None:
+    s = SCAT("scat20161015_20161021.zip", nflights=10, include_waypoints=True)
+    assert isinstance(s.waypoints, pd.DataFrame)
+
+
+def test_scat_weather() -> None:
+    s = SCAT("scat20161015_20161021.zip", nflights=10, include_weather=True)
+    assert isinstance(s.weather, pd.DataFrame)


### PR DESCRIPTION
As discussed [here](https://github.com/xoolive/traffic/issues/436) I added the engine flag to the eval calls. While I was at it, I also implemented some functions for loading the waypoints and weather data. Existing code should not break as I added the additional flags `include_weather` and `include_waypoints` and set them to `False` by default.
Both weather and waypoints are just dataframes right now because there is some information missing from the waypoints which would be needed to make them Navaid objects. The weather data is decoded grib format which is different from the implemented metar data format.

Let me know what you think!
Thanks