### PR TITLE
Interpolation Options for Trajectory Resampling

### DIFF
--- a/src/traffic/core/flight.py
+++ b/src/traffic/core/flight.py
@@ -1658,7 +1658,7 @@ class Flight(
         self,
         rule: str | int = "1s",
         how: None | str | dict[str, Iterable[str]] = "interpolate",
-        interpolation_options: dict[str, Any] = {},
+        interpolate_kw: dict[str, Any] = {},
         projection: None | str | pyproj.Proj | "crs.Projection" = None,
     ) -> Flight:
         """Resample the trajectory at a given frequency or for a target number
@@ -1681,7 +1681,7 @@ class Flight(
               ``"interpolate"``, ``"ffill"``) and names of columns as values.
               Columns not included in any value are left as is.
 
-        :param interpolation_options: (default: ``{}``)
+        :param interpolate_kw: (default: ``{}``)
 
             - A dictionary with keyword arguments that will be passed to the
               pandas :py:method:`pandas.Series.interpolate` method.
@@ -1691,7 +1691,7 @@ class Flight(
               pass the following dictionary:
 
               .. code-block:: python
-              interpolation_options = {"method": "polynomial", "order": 5}
+              interpolate_kw = {"method": "polynomial", "order": 5}
 
         :param projection: (default: ``None``)
 
@@ -1742,9 +1742,7 @@ class Flight(
             for meth, columns in how.items():
                 if meth is not None:
                     idx = data.columns.get_indexer(columns)
-                    kwargs = (
-                        interpolation_options if meth == "interpolate" else {}
-                    )
+                    kwargs = interpolate_kw if meth == "interpolate" else {}
                     value = getattr(data.iloc[:, idx], meth)(**kwargs)
                     data[data.columns[idx]] = value
 

--- a/src/traffic/core/flight.py
+++ b/src/traffic/core/flight.py
@@ -1658,6 +1658,7 @@ class Flight(
         self,
         rule: str | int = "1s",
         how: None | str | dict[str, Iterable[str]] = "interpolate",
+        interpolation_options: dict[str, Any] = {},
         projection: None | str | pyproj.Proj | "crs.Projection" = None,
     ) -> Flight:
         """Resample the trajectory at a given frequency or for a target number
@@ -1679,6 +1680,18 @@ class Flight(
             - When the parameter is a dictionary with keys as methods (e.g.
               ``"interpolate"``, ``"ffill"``) and names of columns as values.
               Columns not included in any value are left as is.
+
+        :param interpolation_options: (default: ``{}``)
+
+            - A dictionary with keyword arguments that will be passed to the
+              pandas :py:method:`pandas.Series.interpolate` method.
+
+              Example usage:
+              To specify a fifth-degree polynomial interpolation, you can
+              pass the following dictionary:
+
+              .. code-block:: python
+              interpolation_options = {"method": "polynomial", "order": 5}
 
         :param projection: (default: ``None``)
 
@@ -1729,7 +1742,10 @@ class Flight(
             for meth, columns in how.items():
                 if meth is not None:
                     idx = data.columns.get_indexer(columns)
-                    value = getattr(data.iloc[:, idx], meth)()
+                    kwargs = (
+                        interpolation_options if meth == "interpolate" else {}
+                    )
+                    value = getattr(data.iloc[:, idx], meth)(**kwargs)
                     data[data.columns[idx]] = value
 
         elif isinstance(rule, int):

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -524,7 +524,7 @@ def test_resample_how_argument() -> None:
     resampled_interpolate_quadratic = Flight(df).resample(
         "1s",
         how="interpolate",
-        interpolation_options={"method": "polynomial", "order": 2},
+        interpolate_kw={"method": "polynomial", "order": 2},
     )
     pd.testing.assert_frame_equal(
         resampled_interpolate_quadratic.data[["altitude", "fake"]],

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -508,6 +508,36 @@ def test_resample_how_argument() -> None:
         check_dtype=False,
     )
 
+    altitude_interpolate_quadratic = [
+        30000.0,
+        28440.0,
+        27160.0,
+        26160.0,
+        25440.0,
+        25000.0,
+        24840.0,
+        24960.0,
+        25360.0,
+        26040.0,
+        27000.0,
+    ]
+    resampled_interpolate_quadratic = Flight(df).resample(
+        "1s",
+        how="interpolate",
+        interpolation_options={"method": "polynomial", "order": 2},
+    )
+    pd.testing.assert_frame_equal(
+        resampled_interpolate_quadratic.data[["altitude", "fake"]],
+        pd.DataFrame(
+            {
+                "altitude": altitude_interpolate_quadratic,
+                "fake": fake_interpolate,
+            }
+        ),
+        check_dtype=False,
+        check_exact=False,  # accomodate for small rounding errors
+    )
+
     resampled_ffill = Flight(df).resample("1s", how="ffill")
     pd.testing.assert_frame_equal(
         resampled_ffill.data[["altitude", "fake"]],


### PR DESCRIPTION
This PR adresses issue https://github.com/xoolive/traffic/issues/440.

Changes made:

- [x] added `interpolation_options` argument to `resample` method in `Flight`.
- [x] extended documentation to include the new argument.
- [x] extended the test case `test_resample_how_argument` to include a quadratic interpolation.

Before merging, please check if the documentation is sufficient and whether the intersphinx link to pandas is working, I did not test that.

Also please note that I set the flag `check_exact=False` for the test case because I had small rounding inaccuracies at 1e-6 and I was unsure if they are deterministic.

Thanks!