### PR TITLE
fuel: Fix for openap 2.0

### DIFF
--- a/src/traffic/algorithms/openap.py
+++ b/src/traffic/algorithms/openap.py
@@ -154,7 +154,7 @@ class OpenAP:
             count(1), TAS, altitude, path_angle, dt
         ):
             ff = fuelflow.enroute(
-                mass=mass[i - 1], tas=tas, alt=alt, path_angle=pa
+                mass=mass[i - 1], tas=tas, alt=alt, vs=pa
             )
             if update_mass:
                 mass[i:] -= ff * dti if ff == ff else 0


### PR DESCRIPTION
Uses a new fuel model based on https://github.com/DGAC/Acropole, and acceleration could also be used as a new input.