### PR TITLE
Plotly update

### DIFF
--- a/docs/visualize/plotly.rst
+++ b/docs/visualize/plotly.rst
@@ -24,21 +24,21 @@ traffic provides the same interface as the :meth:`plotly.express` module on
 the :class:`~traffic.core.Flight` and :class:`~traffic.core.Traffic` classes.
 All kwargs arguments are passed directly to the corresponding method.
 
-- with :func:`plotly.express.line_mapbox`:
+- with :func:`plotly.express.line_map`:
 
   .. jupyter-execute::
 
     from traffic.data.samples import belevingsvlucht
 
-    belevingsvlucht.line_mapbox(color="callsign")
+    belevingsvlucht.line_map(color="callsign")
 
-- with :func:`plotly.express.scatter_mapbox`:
+- with :func:`plotly.express.scatter_map`:
 
   .. jupyter-execute::
 
     from traffic.data.samples import belevingsvlucht
 
-    fig = belevingsvlucht.scatter_mapbox(
+    fig = belevingsvlucht.scatter_map(
         color="altitude", width=600, height=600, zoom=6
     )
     fig.update_layout(margin=dict(l=50, r=0, t=40, b=40))
@@ -49,7 +49,7 @@ All kwargs arguments are passed directly to the corresponding method.
 
     from traffic.data.samples import belevingsvlucht
 
-    belevingsvlucht.resample("1 min").scatter_mapbox(
+    belevingsvlucht.resample("1 min").scatter_map(
         color="vertical_rate",
         range_color=[-4000, 4000],
         animation_frame="timestamp",
@@ -69,7 +69,7 @@ It is also possible to combine elements by constructing a
 
   # fig = go.Figure()  # if necessary, we can initiate a Figure and fill it later
 
-  fig = belevingsvlucht.resample("1 min").scatter_mapbox(
+  fig = belevingsvlucht.resample("1 min").scatter_map(
       color="vertical_rate",
       range_color=[-2000, 2000],
       animation_frame="timestamp",
@@ -109,13 +109,13 @@ Or by combining several traces:
     assert subset is not None
 
 
-    fig = subset.scatter_mapbox(
+    fig = subset.scatter_map(
         color="callsign",
         hover_data="altitude",
         animation_frame="timestamp",
         center=airports["LFPO"].latlon_dict,
     )
-    fig = fig.add_traces(subset.line_mapbox(
+    fig = fig.add_traces(subset.line_map(
             color="callsign",
         ).data)
     fig.update_layout(margin=dict(l=0, r=0, t=0, b=0))

--- a/src/traffic/core/flight.py
+++ b/src/traffic/core/flight.py
@@ -283,7 +283,7 @@ class Flight(
           :meth:`geoencode`
 
         - visualisation with leaflet: :meth:`map_leaflet`
-        - visualisation with plotly: :meth:`line_mapbox` and others
+        - visualisation with plotly: :meth:`line_map` and others
         - visualisation with Matplotlib:
           :meth:`plot`,
           :meth:`plot_time`
@@ -2998,7 +2998,7 @@ class Flight(
     def line_geo(self, **kwargs: Any) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
-    def line_mapbox(
+    def line_map(
         self, mapbox_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
@@ -3006,7 +3006,7 @@ class Flight(
     def scatter_geo(self, **kwargs: Any) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
-    def scatter_mapbox(
+    def scatter_map(
         self, mapbox_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
@@ -3147,13 +3147,13 @@ def patch_plotly() -> None:
         Scattergeo,
         Scattermapbox,
         line_geo,
-        line_mapbox,
+        line_map,
         scatter_geo,
-        scatter_mapbox,
+        scatter_map,
     )
 
-    Flight.line_mapbox = line_mapbox  # type: ignore
-    Flight.scatter_mapbox = scatter_mapbox  # type: ignore
+    Flight.line_map = line_map  # type: ignore
+    Flight.scatter_map = scatter_map  # type: ignore
     Flight.Scattermapbox = Scattermapbox  # type: ignore
     Flight.line_geo = line_geo  # type: ignore
     Flight.scatter_geo = scatter_geo  # type: ignore

--- a/src/traffic/core/flight.py
+++ b/src/traffic/core/flight.py
@@ -2999,7 +2999,7 @@ class Flight(
         raise ImportError("Install plotly or traffic with the plotly extension")
 
     def line_map(
-        self, mapbox_style: str = "carto-positron", **kwargs: Any
+        self, map_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
@@ -3007,7 +3007,7 @@ class Flight(
         raise ImportError("Install plotly or traffic with the plotly extension")
 
     def scatter_map(
-        self, mapbox_style: str = "carto-positron", **kwargs: Any
+        self, map_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
@@ -3145,7 +3145,7 @@ class Flight(
 def patch_plotly() -> None:
     from ..visualize.plotly import (
         Scattergeo,
-        Scattermapbox,
+        Scattermap,
         line_geo,
         line_map,
         scatter_geo,
@@ -3154,7 +3154,7 @@ def patch_plotly() -> None:
 
     Flight.line_map = line_map  # type: ignore
     Flight.scatter_map = scatter_map  # type: ignore
-    Flight.Scattermapbox = Scattermapbox  # type: ignore
+    Flight.Scattermap = Scattermap  # type: ignore
     Flight.line_geo = line_geo  # type: ignore
     Flight.scatter_geo = scatter_geo  # type: ignore
     Flight.Scattergeo = Scattergeo  # type: ignore

--- a/src/traffic/core/traffic.py
+++ b/src/traffic/core/traffic.py
@@ -1091,7 +1091,7 @@ class Traffic(HBoxMixin, GeographyMixin):
     def line_geo(self, **kwargs: Any) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
-    def line_mapbox(
+    def line_map(
         self, mapbox_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
@@ -1099,7 +1099,7 @@ class Traffic(HBoxMixin, GeographyMixin):
     def scatter_geo(self, **kwargs: Any) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
-    def scatter_mapbox(
+    def scatter_map(
         self, mapbox_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
@@ -1529,13 +1529,13 @@ def patch_plotly() -> None:
         Scattergeo,
         Scattermapbox,
         line_geo,
-        line_mapbox,
+        line_map,
         scatter_geo,
-        scatter_mapbox,
+        scatter_map,
     )
 
-    Traffic.line_mapbox = line_mapbox  # type: ignore
-    Traffic.scatter_mapbox = scatter_mapbox  # type: ignore
+    Traffic.line_map = line_map  # type: ignore
+    Traffic.scatter_map = scatter_map  # type: ignore
     Traffic.Scattermapbox = Scattermapbox  # type: ignore
     Traffic.line_geo = line_geo  # type: ignore
     Traffic.scatter_geo = scatter_geo  # type: ignore

--- a/src/traffic/core/traffic.py
+++ b/src/traffic/core/traffic.py
@@ -1092,7 +1092,7 @@ class Traffic(HBoxMixin, GeographyMixin):
         raise ImportError("Install plotly or traffic with the plotly extension")
 
     def line_map(
-        self, mapbox_style: str = "carto-positron", **kwargs: Any
+        self, map_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
@@ -1100,7 +1100,7 @@ class Traffic(HBoxMixin, GeographyMixin):
         raise ImportError("Install plotly or traffic with the plotly extension")
 
     def scatter_map(
-        self, mapbox_style: str = "carto-positron", **kwargs: Any
+        self, map_style: str = "carto-positron", **kwargs: Any
     ) -> "go.Figure":
         raise ImportError("Install plotly or traffic with the plotly extension")
 
@@ -1527,7 +1527,7 @@ class Traffic(HBoxMixin, GeographyMixin):
 def patch_plotly() -> None:
     from ..visualize.plotly import (
         Scattergeo,
-        Scattermapbox,
+        Scattermap,
         line_geo,
         line_map,
         scatter_geo,
@@ -1536,7 +1536,7 @@ def patch_plotly() -> None:
 
     Traffic.line_map = line_map  # type: ignore
     Traffic.scatter_map = scatter_map  # type: ignore
-    Traffic.Scattermapbox = Scattermapbox  # type: ignore
+    Traffic.Scattermap = Scattermap  # type: ignore
     Traffic.line_geo = line_geo  # type: ignore
     Traffic.scatter_geo = scatter_geo  # type: ignore
     Traffic.Scattergeo = Scattergeo  # type: ignore

--- a/src/traffic/visualize/plotly.py
+++ b/src/traffic/visualize/plotly.py
@@ -6,7 +6,7 @@ import plotly.graph_objects as go
 
 def line_map(
     self: Any,
-    mapbox_style: str = "carto-positron",
+    map_style: str = "carto-positron",
     **kwargs: Any,
 ) -> go.Figure:
     """Create a line plot with Plotly.
@@ -21,13 +21,13 @@ def line_map(
         self.data,
         lat="latitude",
         lon="longitude",
-        mapbox_style=mapbox_style,
+        map_style=map_style,
         **kwargs,
     )
 
 
 def scatter_map(
-    self: Any, mapbox_style: str = "carto-positron", **kwargs: Any
+    self: Any, map_style: str = "carto-positron", **kwargs: Any
 ) -> go.Figure:
     """Create a scatter plot with Plotly.
 
@@ -41,17 +41,17 @@ def scatter_map(
         self.data,
         lat="latitude",
         lon="longitude",
-        mapbox_style=mapbox_style,
+        map_style=map_style,
         **kwargs,
     )
 
 
-def Scattermapbox(self: Any, **kwargs: Any) -> go.Scattermapbox:
-    """Create a Scattermapbox with Plotly.
+def Scattermap(self: Any, **kwargs: Any) -> go.Scattermap:
+    """Create a Scattermap with Plotly.
 
     Requires the plotly package (optional dependency).
     """
-    return go.Scattermapbox(
+    return go.Scattermap(
         lat=self.data.latitude,
         lon=self.data.longitude,
         **kwargs,
@@ -93,7 +93,7 @@ def scatter_geo(self: Any, **kwargs: Any) -> go.Figure:
 
 
 def Scattergeo(self: Any, **kwargs: Any) -> go.Scattergeo:
-    """Create a Scattermapbox with Plotly.
+    """Create a Scattergeo with Plotly.
 
     Requires the plotly package (optional dependency).
     """

--- a/src/traffic/visualize/plotly.py
+++ b/src/traffic/visualize/plotly.py
@@ -4,7 +4,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 
-def line_mapbox(
+def line_map(
     self: Any,
     mapbox_style: str = "carto-positron",
     **kwargs: Any,
@@ -17,7 +17,7 @@ def line_mapbox(
         if (point := getattr(self, "point", None)) is not None:
             kwargs["center"] = point.latlon_dict
 
-    return px.line_mapbox(
+    return px.line_map(
         self.data,
         lat="latitude",
         lon="longitude",
@@ -26,7 +26,7 @@ def line_mapbox(
     )
 
 
-def scatter_mapbox(
+def scatter_map(
     self: Any, mapbox_style: str = "carto-positron", **kwargs: Any
 ) -> go.Figure:
     """Create a scatter plot with Plotly.

--- a/src/traffic/visualize/plotly.py
+++ b/src/traffic/visualize/plotly.py
@@ -37,7 +37,7 @@ def scatter_map(
         if (point := getattr(self, "point", None)) is not None:
             kwargs["center"] = point.latlon_dict
 
-    return px.scatter_mapbox(
+    return px.scatter_map(
         self.data,
         lat="latitude",
         lon="longitude",


### PR DESCRIPTION
Plotly has swtiched to maplibre instead of [mapbox:](https://plotly.com/blog/plotly-is-switching-to-maplibre/).
This PR updates all traffic related Plotly functions to transition to MapLibre.
