### PR TITLE
Fix import issue in traffic.data.opensky

### DIFF
--- a/src/traffic/data/adsb/opensky.py
+++ b/src/traffic/data/adsb/opensky.py
@@ -195,9 +195,9 @@ class OpenSky:
         df = self.rest_client.tracks(icao24, time).pipe(format_history)
         return Flight(df)
 
-    @copy_documentation(rest.REST.routes)
-    def api_routes(self, callsign: str) -> tuple[str, str]:
-        return self.rest_client.routes(callsign)
+    # @copy_documentation(rest.REST.routes)
+    # def api_routes(self, callsign: str) -> tuple[str, str]:
+    #     return self.rest_client.routes(callsign)
 
     @copy_documentation(rest.REST.aircraft)
     def api_aircraft(

--- a/tests/test_opensky.py
+++ b/tests/test_opensky.py
@@ -1,0 +1,3 @@
+def test_opensky_import():
+    from traffic.data import opensky
+    assert opensky is not None


### PR DESCRIPTION
Fix import issue in traffic.data.opensky because of a change in the pyopensky library. 
Addition of an opensky test. 