### PR TITLE
Fix handling of cached method when `Airport` object is pickled

### DIFF
--- a/src/traffic/core/structure.py
+++ b/src/traffic/core/structure.py
@@ -123,6 +123,14 @@ class Airport(FormatMixin, HBoxMixin, PointMixin, ShapelyMixin):
             nwr=[dict(aeroway=True, area="airport")],
         )
 
+    def __getstate__(self) -> object:
+        state = self.__dict__.copy()
+        state.pop("_openstreetmap", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def leaflet(self, **kwargs: Any) -> "LeafletGeoData":
         # The code is monkey-patched in src/visualize/leaflet.py
         raise ImportError(

--- a/tests/test_aircraft.py
+++ b/tests/test_aircraft.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 import pandas as pd
@@ -58,3 +60,10 @@ def test_country() -> None:
     a = Aircraft(pd.DataFrame(act)).get(reg)
     assert a is not None
     assert a["country"] == "Democratic Republic of the Congo"
+
+
+def test_pickling() -> None:
+    original = aircraft["PH-BHA"]
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_airports.py
+++ b/tests/test_airports.py
@@ -1,3 +1,4 @@
+import pickle
 import zipfile
 
 import pytest
@@ -69,3 +70,10 @@ def test_runway_bearing() -> None:
                 delta = 360 - delta
             # It can be as big as 25 degrees with parallel runways!
             assert delta < 25, f"Error with airport {apt_name} {runway.name}"
+
+
+def test_pickling() -> None:
+    original = airports["CDG"]
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_airspace.py
+++ b/tests/test_airspace.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from traffic.core import Airspace
@@ -40,3 +42,10 @@ def test_area() -> None:
 def test_nm() -> None:
     maastricht = nm_airspaces["EDYYUTAX"]
     assert maastricht.area > 1e11
+
+
+def test_pickling() -> None:
+    original = eurofirs["EHAA"]
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_airways.py
+++ b/tests/test_airways.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from traffic.data import airways, eurofirs
@@ -60,3 +62,10 @@ def test_through_extent() -> None:
         short_un871["ERROR", "LARDA"]
     with pytest.raises(ValueError):
         short_un871["LARDA", "ERROR"]
+
+
+def test_pickling() -> None:
+    original = airways["L888"]
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 from operator import itemgetter
 from typing import Any, cast
@@ -665,3 +666,10 @@ def test_split_map() -> None:
     )
     assert result is not None
     assert 140 <= len(result) <= 160
+
+
+def test_pickling() -> None:
+    original = belevingsvlucht
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_navaid.py
+++ b/tests/test_navaid.py
@@ -1,3 +1,5 @@
+import pickle
+
 from traffic.data import eurofirs, navaids
 
 
@@ -30,3 +32,10 @@ def test_iter() -> None:
     nav_ext = navaids.extent(extent)
     assert nav_ext is not None
     assert sum(1 for n in nav_ext if n.name == "GAI") == 1
+
+
+def test_pickling() -> None:
+    original = navaids["GAI"]
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 import pandas as pd
@@ -206,3 +208,10 @@ def test_sub() -> None:
     diff = sw_id - diff
     assert diff is not None
     assert diff.icao24 == {"500142"}
+
+
+def test_pickling() -> None:
+    original = switzerland
+    p = pickle.dumps(original)
+    restored = pickle.loads(p)
+    assert restored is not None


### PR DESCRIPTION
This one fixes #497 by excluding the cached method `_openstreetmap()` when an `Airport` object is pickled. It prevents infinite recursion as described in the bug report.