### PR TITLE
added longitude unwrapping to handle default projections near antimeridian

### DIFF
--- a/src/traffic/core/flight.py
+++ b/src/traffic/core/flight.py
@@ -1756,13 +1756,19 @@ class Flight(HBoxMixin, GeographyMixin, ShapelyMixin, metaclass=MetaFlight):
         """
         if projection is not None:
             if isinstance(projection, str):
+                lon_unwrap = np.degrees(np.unwrap(np.radians(self.data.longitude.dropna())))
+                lon0 = lon_unwrap.mean()
+                lon1 = lon_unwrap.min()
+                lon2 = lon_unwrap.max()
                 projection = pyproj.Proj(
-                    proj=projection,
-                    ellps="WGS84",
-                    lat_1=self.data.latitude.min(),
-                    lat_2=self.data.latitude.max(),
-                    lat_0=self.data.latitude.mean(),
-                    lon_0=self.data.longitude.mean(),
+                    proj=projection, 
+                    ellps="WGS84", 
+                    lat_0=self.data.latitude.mean(), 
+                    lat_1=self.data.latitude.min(), 
+                    lat_2=self.data.latitude.max(), 
+                    lon_0=lon0, 
+                    lon_1=lon1, 
+                    lon_2=lon2
                 )
             self = self.compute_xy(projection=projection)
 

--- a/src/traffic/core/mixins.py
+++ b/src/traffic/core/mixins.py
@@ -513,13 +513,19 @@ class GeographyMixin(DataFrameMixin):
     __slots__ = ()
 
     def projection(self, proj: str = "lcc") -> pyproj.Proj:
+        lon_unwrap = np.degrees(np.unwrap(np.radians(self.data.longitude.dropna())))
+        lon0 = lon_unwrap.mean()
+        lon1 = lon_unwrap.min()
+        lon2 = lon_unwrap.max()
         return pyproj.Proj(
-            proj=proj,
-            ellps="WGS84",
-            lat_1=self.data.latitude.min(),
-            lat_2=self.data.latitude.max(),
-            lat_0=self.data.latitude.mean(),
-            lon_0=self.data.longitude.mean(),
+            proj=proj, 
+            ellps="WGS84", 
+            lat_0=self.data.latitude.mean(), 
+            lat_1=self.data.latitude.min(), 
+            lat_2=self.data.latitude.max(), 
+            lon_0=lon0, 
+            lon_1=lon1, 
+            lon_2=lon2
         )
 
     def compute_xy(


### PR DESCRIPTION
Resampling on transpacific flight with default projection `.resample(..., projection='lcc')` cause weird interpolations due to the projection bounds not well defined near the antimeridian. Unwrapping longitudinal coordinates before passing the mean, min, and max to pyproj can help with this problem. Also added unwrapping to default `compute_xy`

See example below.

original flight:
<img width="562" height="318" alt="original_flight" src="https://github.com/user-attachments/assets/272899cb-5b8b-4767-ab5a-4862454a374c" />

incorrect projection and resample:
<img width="562" height="318" alt="incorrect_projection" src="https://github.com/user-attachments/assets/77573988-d02b-4013-bbf0-604ce4b599c9" />

corrected projection and resample:
<img width="562" height="318" alt="correct_projection" src="https://github.com/user-attachments/assets/86181dbf-4b9f-4348-bca1-2ab6deb0eae8" />
