### PR TITLE
adapt signature of traffic.resample method to match other methods.

### DIFF
--- a/src/traffic/core/traffic.py
+++ b/src/traffic/core/traffic.py
@@ -804,7 +804,7 @@ class Traffic(HBoxMixin, GeographyMixin):
         ...
 
     @lazy_evaluation()
-    def resample(self, /, rule: Union[str, int] = "1s"):  # type: ignore
+    def resample(self, /, *args, **kwargs):  # type: ignore
         ...
 
     @lazy_evaluation()


### PR DESCRIPTION
The signature of `Traffic.resample` does not match the one of `Flight.resample`. Hence, this PR fixes a type checker issue in user code by adapting the method's signature to a more generic one, like it is done for other lazy methods in `Traffic`.