### PR TITLE
fix: handle pyarrow-backed onground in FilterClustering

### DIFF
--- a/src/traffic/algorithms/filters/aggressive.py
+++ b/src/traffic/algorithms/filters/aggressive.py
@@ -137,7 +137,7 @@ class FilterClustering(FilterBase):
             if column not in data.columns:
                 continue
             if column == "onground":
-                statechange = data[column].diff().astype(bool)
+                statechange = data[column].diff().fillna(False).astype(bool)
                 data["group"] = statechange.eq(True).cumsum()
                 groups = data["group"].value_counts()
                 keepers = groups[groups > param["group_size"]].index.tolist()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,6 +1,8 @@
 import pytest
 from cartes.crs import Lambert93  # type: ignore
 
+import pandas as pd
+from traffic.algorithms.filters.aggressive import FilterClustering
 from traffic.algorithms.filters.ekf import EKF
 from traffic.algorithms.ground.kalman_taxiway import KalmanTaxiway
 from traffic.data.samples import full_flight_short
@@ -46,3 +48,40 @@ def test_ekf() -> None:
 
     # assert distance.lateral.max() <  # currently 0
     assert distance.vertical.max() < 50
+
+
+def test_filter_clustering_onground_pyarrow() -> None:
+    """FilterClustering must handle pyarrow-backed bool onground with NA.
+
+    When pandas (2.x or 3.x) reads ADS-B data from parquet, boolean
+    columns like ``onground`` use the ``bool[pyarrow]`` dtype.  After
+    resampling, NA values appear.  ``FilterClustering`` calls
+    ``diff().astype(bool)`` which raises
+    ``TypeError: boolean value of NA is ambiguous`` unless NA values
+    are handled before the cast.
+    """
+    n = 50
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range(
+                "2025-01-01", periods=n, freq="1s", tz="UTC"
+            ),
+            "latitude": [48.0 + i * 0.001 for i in range(n)],
+            "longitude": [2.0 + i * 0.001 for i in range(n)],
+            "altitude": [35000.0] * n,
+            "groundspeed": [450.0] * n,
+            "track": [180.0] * n,
+            "vertical_rate": [0.0] * n,
+            # pyarrow bool with NA — reproduces post-resample state
+            "onground": pd.array(
+                [False] * 20 + [None] * 10 + [False] * 20,
+                dtype="bool[pyarrow]",
+            ),
+        }
+    )
+
+    filt = FilterClustering()
+    result = filt.apply(df)
+
+    assert len(result) == n
+    assert "onground" in result.columns


### PR DESCRIPTION
## Problem

`FilterClustering.apply()` raises `TypeError: boolean value of NA is ambiguous` when the `onground` column has the `bool[pyarrow]` dtype — a scenario that occurs naturally when pandas (2.x or 3.x) reads ADS-B data from parquet and resamples it.

This is a follow-up to 67aea13 which fixed the same class of pyarrow issues in `FilterDerivative` and in the `else` branch of `FilterClustering`, but missed the `if column == "onground"` branch.

## Environment

Tested on:

| Component | pandas 2.x | pandas 3.x |
|---|---|---|
| pandas | 2.3.3 | 3.0.1 |
| pyarrow | 23.0.1 | 23.0.1 |
| Python | 3.12 | 3.12 |
| Bug reproduces? | ✅ Yes | ✅ Yes |
| Fix works? | ✅ Yes | ✅ Yes |

## Reproduction

```python
import pandas as pd
from traffic.algorithms.filters.aggressive import FilterClustering

n = 50
df = pd.DataFrame({
    "timestamp": pd.date_range("2025-01-01", periods=n, freq="1s", tz="UTC"),
    "latitude": [48.0] * n,
    "longitude": [2.0] * n,
    "altitude": [35000.0] * n,
    "groundspeed": [450.0] * n,
    "track": [180.0] * n,
    "vertical_rate": [0.0] * n,
    "onground": pd.array(
        [False] * 20 + [None] * 10 + [False] * 20,
        dtype="bool[pyarrow]",
    ),
})

filt = FilterClustering()
filt.apply(df)
# TypeError: boolean value of NA is ambiguous
```

This also reproduces end-to-end with real OpenSky data:

```python
from traffic.core import Traffic

t = Traffic.from_file("history.parquet")  # any OpenSky parquet
flight = t[0]
flight.filter().resample("1s", how=None).filter("aggressive")
# Same TypeError on the onground column
```

## Root cause

`FilterClustering.apply()`, line 140:

```python
statechange = data[column].diff().astype(bool)
```

`diff()` on a `bool[pyarrow]` Series produces `pd.NA` for the first row and for positions adjacent to existing NA values. `pd.NA` cannot be cast to `bool` (by design — its truth value is ambiguous), so `astype(bool)` raises `TypeError`.

The `else` branch of the same method was already fixed in 67aea13 with `fillna(False)`, but the `onground` branch was missed.

## Fix

Single insertion — add `fillna(False)` before the cast:

```diff
- statechange = data[column].diff().astype(bool)
+ statechange = data[column].diff().fillna(False).astype(bool)
```

A missing diff means "no state change", correctly represented as `False`.

## Tests

Added `test_filter_clustering_onground_pyarrow` in `tests/test_filter.py`:
- Creates a synthetic DataFrame with `bool[pyarrow]` `onground` column containing NA values
- Verifies `FilterClustering.apply()` runs without error and preserves all rows
- Confirmed the test **fails** on master and **passes** with this fix
- Verified on both pandas 2.3.3 and pandas 3.0.1