### PR TITLE
fix: align tooling config and docs with requires-python >=3.11

### DIFF
--- a/docs/gallery/covid19.rst
+++ b/docs/gallery/covid19.rst
@@ -82,7 +82,7 @@ Currently, the trend shows:
 Data collection and preparation
 ===============================
 
-On the `Impala shell <../opensky_impala.html>`_, a particular table contains flight lists with associated origin and destination airport. The data has been downloaded using the `opensky.flightlist <https://traffic-viz.github.io/opensky_impala.html#traffic.data.adsb.opensky_impala.Impala.flightlist>`_ method, curated, then aggregated with aircraft and flight number information before being published `here <https://opensky-network.org/datasets/covid-19/>`_. Download the data and run the following:
+On the `Impala shell <../data_sources/opensky_db.html>`_, a particular table contains flight lists with associated origin and destination airport. The data has been downloaded using the ``opensky.flightlist`` method, curated, then aggregated with aircraft and flight number information before being published `here <https://opensky-network.org/datasets/covid-19/>`_. Download the data and run the following:
 
 .. code:: python
 

--- a/docs/gallery/heatmaps.rst
+++ b/docs/gallery/heatmaps.rst
@@ -17,7 +17,7 @@ You will find below the code producing the following maps.
    :align: center
 
 
-First download the data from the `Impala shell </opensky_impala.html>`__ over your area of interest (ground trajectories are kept out of the dataset).
+First download the data from the `Impala shell </data_sources/opensky_db.html>`__ over your area of interest (ground trajectories are kept out of the dataset).
 
 .. code:: python
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,10 +21,10 @@ We recommend creating a fresh conda environment for a first installation:
 .. code:: bash
 
     # Installation
-    conda create -n traffic -c conda-forge python=3.10 traffic
+    conda create -n traffic -c conda-forge python=3.11 traffic
     conda activate traffic
 
-Adjust the Python version you need (>=3.9) and append packages you need for
+Adjust the Python version you need (>=3.11) and append packages you need for
 working efficiently, such as Jupyter Lab, xarray, PyTorch or more.
 
 Then activate the environment each time you need to use the ``traffic`` library:

--- a/docs/paper/atc_detect.rst
+++ b/docs/paper/atc_detect.rst
@@ -34,7 +34,7 @@ TMA.
     )
 
 The data has been downloaded from the `OpenSky Network Impala
-database <../opensky_usage.html>`__. The following recalls all the
+database <../data_sources/opensky_db.html>`__. The following recalls all the
 callsigns selected for this route.
 
 .. code:: python

--- a/docs/paper/sectflow.rst
+++ b/docs/paper/sectflow.rst
@@ -34,7 +34,7 @@ Data preparation
 
 
 The data has been downloaded from the `OpenSky Network Impala
-database <../opensky_usage.html>`__.
+database <../data_sources/opensky_db.html>`__.
 
 First a `clustering <../clustering.html>`_ is applied to the dataset. The
 implementation of the specific clustering described in the paper is available on

--- a/docs/troubleshooting/installation.rst
+++ b/docs/troubleshooting/installation.rst
@@ -8,7 +8,7 @@ There are three installation processes:
 
   .. code:: bash
 
-     conda create -n traffic -c conda-forge python=3.9 traffic
+     conda create -n traffic -c conda-forge python=3.11 traffic
 
 - the pip way, but you are responsible for non Python dependency management.
   With Linux, you may check how the environment is created for GitHub Actions;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -96,7 +95,7 @@ fallback-version = "0.0.0"
 
 [tool.ruff]
 line-length = 80
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [
@@ -113,7 +112,7 @@ select = [
 known-first-party = ["numpy", "pandas", "pyproj", "shapely"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 platform = "posix"
 
 color_output = true


### PR DESCRIPTION
 ## Summary

  `requires-python` is set to `>=3.11`, but several tooling configs and documentation pages still reference Python 3.9 or 3.10. This PR brings     
  everything into alignment.

  ### Tooling config (`pyproject.toml`)

  | Setting | Before | After |
  |---|---|---|
  | `[tool.ruff] target-version` | `"py310"` | `"py311"` |
  | `[tool.mypy] python_version` | `"3.10"` | `"3.11"` |
  | Trove classifier | includes `Python :: 3.10` | removed (not installable on 3.10) |

  ### Documentation — Python version references

  - `docs/installation.rst`: conda example used `python=3.10` and noted `>=3.9` — updated to `3.11` and `>=3.11`
  - `docs/troubleshooting/installation.rst`: conda example used `python=3.9` — updated to `3.11`

  ### Documentation — broken links

  Several pages linked to `opensky_impala.html` or `opensky_usage.html`, which no longer exist. Updated to point to `data_sources/opensky_db.html`:

  - `docs/gallery/heatmaps.rst`
  - `docs/gallery/covid19.rst` (also removed a dead external link to `traffic-viz.github.io/opensky_impala.html`)
  - `docs/paper/sectflow.rst`
  - `docs/paper/atc_detect.rst`

  ## Verification

  - `ruff check` passes with the new `py311` target
  - `ruff format --check` passes
  - No code changes — config and docs only