### PR TITLE
docs: fill in own_data user guide page (#312)

### DIFF
--- a/docs/user_guide/own_data.rst
+++ b/docs/user_guide/own_data.rst
@@ -1,2 +1,50 @@
 How to bring your own data in the traffic library?
 ==================================================
+
+``Flight`` and ``Traffic`` wrap a pandas DataFrame without validating,
+renaming, or converting anything: the DataFrame you pass in must already use
+the column names the library expects.
+
+Required columns
+-----------------
+
+The minimum set of columns, as described in the ``Flight`` class
+documentation, is:
+
+- ``icao24``: the ICAO transponder ID of an aircraft;
+- ``callsign``: an identifier associated with the registration of an
+  aircraft, its mission, or a route;
+- ``timestamp``: timezone aware timestamps are preferable;
+- ``latitude``, ``longitude``: in degrees, WGS84 (EPSG:4326);
+- ``altitude``: in feet. Data recorded in meters must be converted before
+  use, e.g. ``altitude_ft = altitude_m / 0.3048``.
+
+A ``flight_id`` column may be used in place of the (``icao24``, ``callsign``)
+pair, which is useful when a dataset has no ``callsign`` column.
+
+Loading a CSV file
+-------------------
+
+Consider a CSV file with columns ``icao24``, ``datetime``, ``lat``, ``lon``
+and ``alt``. The columns must be renamed, and the timestamp column must be
+converted to a timezone aware datetime:
+
+.. code-block:: python
+
+    import pandas as pd
+    from traffic.core import Flight
+
+    df = pd.read_csv("example_flight.csv").rename(
+        columns={
+            "datetime": "timestamp",
+            "lat": "latitude",
+            "lon": "longitude",
+            "alt": "altitude",
+        }
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+
+    flight = Flight(df)
+
+Timezone naive timestamps may work with some methods, but the behaviour is
+not guaranteed: converting to UTC with ``utc=True`` avoids this.


### PR DESCRIPTION
docs/user_guide/own_data.rst has been a title-only stub since it was created in February 2022. This fills it in.

The page now lists the minimum column set with units, and walks through loading a CSV whose columns don't match — renaming, and converting the timestamp to a timezone-aware datetime.

Issue #312 describes a user with trajectory data in a CSV who couldn't work out from the docs how to load it. What makes this worth documenting is that Flight and Traffic wrap a DataFrame without validating or renaming anything, so mismatched column names don't fail at construction — they fail later, in whichever method expected the column. That's a hard first experience to debug, and loading your own data is one of the first things a new user tries.

I used .. code-block:: python rather than .. jupyter-execute:: as other user guide pages do, because I couldn't build the docs locally to verify a runnable block would pass. Happy to convert it if you'd prefer consistency.

First contribution here. I didn't find a CONTRIBUTING file, so I followed the conventions in the existing docs/user_guide/ pages — let me know if you'd like it structured differently.

Closes #312